### PR TITLE
Add intl extension to backend image

### DIFF
--- a/app/backend/Dockerfile
+++ b/app/backend/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get update && apt-get install -y \
     libonig-dev \
     libxml2-dev \
     libpq-dev \
+    libicu-dev \
     zip \
     unzip \
     libzip-dev
@@ -20,7 +21,7 @@ RUN apt-get update && apt-get install -y \
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install PHP extensions
-RUN docker-php-ext-install pdo_mysql pdo_pgsql mbstring exif pcntl bcmath gd zip
+RUN docker-php-ext-install pdo_mysql pdo_pgsql mbstring exif pcntl bcmath gd zip intl
 
 # Install Redis extension
 RUN pecl install redis && docker-php-ext-enable redis


### PR DESCRIPTION
- Motivo: El contenedor backend fallaba esperando la DB porque php artisan db:show requería la extensión PHP intl y no estaba instalada; el entrypoint se quedaba en timeout.
- Cambios: Se agrega libicu-dev y se instala/habilita intl en la imagen PHP del backend (Dockerfile).
- Resultados: docker compose up -d backend conecta a MySQL, corre migraciones y levanta el servidor sin timeouts (verificado en logs locales).