### PR TITLE
Add establishment to categories - https://napaapp.atlassian.net/browse/SCRUM-206

### DIFF
--- a/app/backend/app/Http/Controllers/Api/V1/ProductCategoryController.php
+++ b/app/backend/app/Http/Controllers/Api/V1/ProductCategoryController.php
@@ -21,11 +21,11 @@ class ProductCategoryController extends Controller
 {
     use ApiResponseTrait;
 
-    private ProductCategoryService $service;
+    private ProductCategoryService $productCategoryService;
 
     public function __construct(ProductCategoryService $service)
     {
-        $this->service = $service;
+        $this->productCategoryService = $service;
     }
 
     /**
@@ -51,12 +51,13 @@ class ProductCategoryController extends Controller
     public function index(ProductCategoryIndexRequest $request): JsonResponse
     {
         try {
-            $categories = $this->service->index(
+            $categories = $this->productCategoryService->getPaginated(
                 $request->validated(),
                 $request->validatedPerPage()
             );
+            $resource = ProductCategoryResource::collection($categories);
 
-            return $this->successResponse(ProductCategoryResource::collection($categories));
+            return $this->paginatedResponse($categories, $resource, 'Product Categories retrieved successfully');
         } catch (Exception $e) {
             return $this->errorResponse('Error fetching product categories', Response::HTTP_INTERNAL_SERVER_ERROR);
         }
@@ -82,7 +83,7 @@ class ProductCategoryController extends Controller
     public function store(StoreProductCategoryRequest $request): JsonResponse
     {
         try {
-            $category = $this->service->store($request->validated());
+            $category = $this->productCategoryService->store($request->validated());
 
             return $this->successResponse(new ProductCategoryResource($category), 'Product Category created successfully', Response::HTTP_CREATED);
         } catch (Exception $e) {
@@ -110,9 +111,9 @@ class ProductCategoryController extends Controller
     public function show(ShowProductCategoryRequest $request, int $id): JsonResponse
     {
         try {
-            $category = $this->service->show($id);
+            $category = $this->productCategoryService->show($id);
 
-            return $this->successResponse(new ProductCategoryResource($category));
+            return $this->successResponse(new ProductCategoryResource($category), 'Product Category retrieved successfully');
         } catch (Exception $e) {
             return $this->errorResponse('Product category not found', Response::HTTP_NOT_FOUND);
         }
@@ -141,7 +142,7 @@ class ProductCategoryController extends Controller
     public function update(UpdateProductCategoryRequest $request, int $id): JsonResponse
     {
         try {
-            $category = $this->service->update($id, $request->validated());
+            $category = $this->productCategoryService->update($id, $request->validated());
 
             return $this->successResponse(new ProductCategoryResource($category), 'Product Category updated successfully', Response::HTTP_OK);
         } catch (Exception $e) {
@@ -169,7 +170,7 @@ class ProductCategoryController extends Controller
     public function destroy(DestroyProductCategoryRequest $request, int $id): JsonResponse
     {
         try {
-            $this->service->destroy($id);
+            $this->productCategoryService->destroy($id);
 
             return response()->json([], Response::HTTP_NO_CONTENT);
         } catch (Exception $e) {

--- a/app/backend/app/Http/Controllers/Api/V1/ProductCategoryController.php
+++ b/app/backend/app/Http/Controllers/Api/V1/ProductCategoryController.php
@@ -38,6 +38,7 @@ class ProductCategoryController extends Controller
      *   security={{"sanctum":{}}},
      *
      *   @OA\Parameter(name="per_page", in="query", required=false, @OA\Schema(type="integer")),
+     *   @OA\Parameter(name="establishment_type_id", in="query", required=false, @OA\Schema(type="integer")),
      *   @OA\Parameter(name="status", in="query", required=false, @OA\Schema(type="string")),
      *   @OA\Parameter(name="name", in="query", required=false, @OA\Schema(type="string")),
      *   @OA\Parameter(name="description", in="query", required=false, @OA\Schema(type="string")),
@@ -50,7 +51,10 @@ class ProductCategoryController extends Controller
     public function index(ProductCategoryIndexRequest $request): JsonResponse
     {
         try {
-            $categories = $this->service->index($request->validated(), $request->validatedPerPage());
+            $categories = $this->service->index(
+                $request->validated(),
+                $request->validatedPerPage()
+            );
 
             return $this->successResponse(ProductCategoryResource::collection($categories));
         } catch (Exception $e) {

--- a/app/backend/app/Http/Requests/Api/V1/ProductCategoryIndexRequest.php
+++ b/app/backend/app/Http/Requests/Api/V1/ProductCategoryIndexRequest.php
@@ -12,6 +12,7 @@ use Illuminate\Foundation\Http\FormRequest;
  *   title="ProductCategoryIndexRequest",
  *   description="Request schema for listing product categories",
  *   type="object",
+ *
  *   @OA\Property(property="per_page", type="integer", description="Items per page (default: 15, max: 100)", minimum=1, maximum=100, example=15),
  *   @OA\Property(property="establishment_type_id", type="integer", description="Establishment type ID", example=2),
  *   @OA\Property(property="status", type="string", description="Status (1=active, 0=inactive)", maxLength=1, example="1"),

--- a/app/backend/app/Http/Requests/Api/V1/ProductCategoryIndexRequest.php
+++ b/app/backend/app/Http/Requests/Api/V1/ProductCategoryIndexRequest.php
@@ -6,6 +6,19 @@ namespace App\Http\Requests\Api\V1;
 
 use Illuminate\Foundation\Http\FormRequest;
 
+/**
+ * @OA\Schema(
+ *   schema="ProductCategoryIndexRequest",
+ *   title="ProductCategoryIndexRequest",
+ *   description="Request schema for listing product categories",
+ *   type="object",
+ *   @OA\Property(property="per_page", type="integer", description="Items per page (default: 15, max: 100)", minimum=1, maximum=100, example=15),
+ *   @OA\Property(property="establishment_type_id", type="integer", description="Establishment type ID", example=2),
+ *   @OA\Property(property="status", type="string", description="Status (1=active, 0=inactive)", maxLength=1, example="1"),
+ *   @OA\Property(property="name", type="string", description="Category name", maxLength=100, example="Bebidas"),
+ *   @OA\Property(property="description", type="string", description="Category description", maxLength=255, example="Categoría de bebidas alcohólicas y no alcohólicas")
+ * )
+ */
 class ProductCategoryIndexRequest extends FormRequest
 {
     public function authorize(): bool
@@ -17,6 +30,7 @@ class ProductCategoryIndexRequest extends FormRequest
     {
         return [
             'per_page' => ['sometimes', 'integer', 'min:1', 'max:100'],
+            'establishment_type_id' => ['sometimes', 'integer', 'exists:establishment_types,id'],
             'status' => ['sometimes', 'string', 'max:1'],
             'name' => ['sometimes', 'string', 'max:100'],
             'description' => ['sometimes', 'string', 'max:255'],

--- a/app/backend/app/Http/Requests/Api/V1/StoreProductCategoryRequest.php
+++ b/app/backend/app/Http/Requests/Api/V1/StoreProductCategoryRequest.php
@@ -13,6 +13,7 @@ use Illuminate\Foundation\Http\FormRequest;
  *
  *   @OA\Property(property="name", type="string", maxLength=100, example="Bebidas", description="Category name"),
  *   @OA\Property(property="description", type="string", maxLength=255, nullable=true, example="Categoría de bebidas", description="Category description"),
+ *   @OA\Property(property="establishment_type_id", type="integer", nullable=true, example=1, description="Establishment type id"),
  *   @OA\Property(property="status", type="string", maxLength=1, example="1", description="Status (1=Activo, 0=Inactivo)"),
  * )
  */
@@ -26,6 +27,7 @@ class StoreProductCategoryRequest extends FormRequest
     public function rules(): array
     {
         return [
+            'establishment_type_id' => ['nullable', 'integer', 'exists:establishment_types,id'],
             'name' => ['required', 'string', 'max:100'],
             'description' => ['nullable', 'string', 'max:255'],
             'status' => ['sometimes', 'string', 'max:1'],

--- a/app/backend/app/Http/Requests/Api/V1/UpdateProductCategoryRequest.php
+++ b/app/backend/app/Http/Requests/Api/V1/UpdateProductCategoryRequest.php
@@ -12,6 +12,7 @@ use Illuminate\Foundation\Http\FormRequest;
  *
  *   @OA\Property(property="name", type="string", maxLength=100, example="Bebidas", description="Category name"),
  *   @OA\Property(property="description", type="string", maxLength=255, nullable=true, example="Categoría de bebidas", description="Category description"),
+ *   @OA\Property(property="establishment_type_id", type="integer", nullable=true, example=1, description="Establishment type id"),
  *   @OA\Property(property="status", type="string", maxLength=1, example="1", description="Status (1=Activo, 0=Inactivo)"),
  * )
  */
@@ -25,6 +26,7 @@ class UpdateProductCategoryRequest extends FormRequest
     public function rules(): array
     {
         return [
+            'establishment_type_id' => ['nullable', 'integer', 'exists:establishment_types,id'],
             'name' => ['sometimes', 'string', 'max:100'],
             'description' => ['nullable', 'string', 'max:255'],
             'status' => ['sometimes', 'string', 'max:1'],

--- a/app/backend/app/Http/Resources/Api/V1/ProductCategoryResource.php
+++ b/app/backend/app/Http/Resources/Api/V1/ProductCategoryResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Resources\Api\V1;
 
 use Illuminate\Http\Resources\Json\JsonResource;
+use App\Http\Resources\Api\V1\EstablishmentTypeResource;
 
 /**
  * @OA\Schema(
@@ -12,6 +13,8 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *   type="object",
  *
  *   @OA\Property(property="id", type="integer"),
+ *   @OA\Property(property="establishment_type_id", type="integer", nullable=true),
+ *   @OA\Property(property="establishment_type", ref="#/components/schemas/EstablishmentTypeResource"),
  *   @OA\Property(property="name", type="string"),
  *   @OA\Property(property="description", type="string", nullable=true),
  *   @OA\Property(property="status", type="string"),
@@ -31,6 +34,10 @@ class ProductCategoryResource extends JsonResource
     {
         return [
             'id' => $this->id,
+            'establishment_type_id' => $this->establishment_type_id,
+            'establishment_type' => $this->whenLoaded('establishmentType', function () {
+                return new EstablishmentTypeResource($this->establishmentType);
+            }),
             'name' => $this->name,
             'description' => $this->description,
             'status' => $this->status,

--- a/app/backend/app/Http/Resources/Api/V1/ProductCategoryResource.php
+++ b/app/backend/app/Http/Resources/Api/V1/ProductCategoryResource.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Http\Resources\Api\V1;
 
 use Illuminate\Http\Resources\Json\JsonResource;
-use App\Http\Resources\Api\V1\EstablishmentTypeResource;
 
 /**
  * @OA\Schema(

--- a/app/backend/app/Models/EstablishmentType.php
+++ b/app/backend/app/Models/EstablishmentType.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use App\Models\Traits\SanitizesTextAttributes;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
@@ -49,5 +50,13 @@ class EstablishmentType extends Model
     public function setCodeAttribute($value)
     {
         $this->attributes['code'] = trim($value);
+    }
+
+    /**
+     * Get the product categories for the establishment type.
+     */
+    public function productCategories(): HasMany
+    {
+        return $this->hasMany(ProductCategory::class, 'establishment_type_id');
     }
 }

--- a/app/backend/app/Models/ProductCategory.php
+++ b/app/backend/app/Models/ProductCategory.php
@@ -51,8 +51,6 @@ class ProductCategory extends Model
 
     /**
      * Get the establishment type that owns the product category.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function establishmentType(): BelongsTo
     {

--- a/app/backend/app/Models/ProductCategory.php
+++ b/app/backend/app/Models/ProductCategory.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use App\Models\Traits\SanitizesTextAttributes;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
@@ -17,6 +18,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property string $name
  * @property string|null $description
  * @property string $status
+ * @property int|null $establishment_type_id
  */
 class ProductCategory extends Model
 {
@@ -28,6 +30,7 @@ class ProductCategory extends Model
      * @var array<int, string>
      */
     protected $fillable = [
+        'establishment_type_id',
         'name',
         'description',
         'status',
@@ -43,7 +46,18 @@ class ProductCategory extends Model
         'name' => 'string',
         'description' => 'string',
         'status' => 'string',
+        'establishment_type_id' => 'integer',
     ];
+
+    /**
+     * Get the establishment type that owns the product category.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function establishmentType(): BelongsTo
+    {
+        return $this->belongsTo(EstablishmentType::class, 'establishment_type_id');
+    }
 
     /**
      * Set the name attribute with sanitization and normalization.

--- a/app/backend/app/Services/ProductCategoryService.php
+++ b/app/backend/app/Services/ProductCategoryService.php
@@ -25,6 +25,9 @@ class ProductCategoryService
         if (isset($filters['status'])) {
             $query->where('status', $filters['status']);
         }
+        if (isset($filters['establishment_type_id'])) {
+            $query->where('establishment_type_id', $filters['establishment_type_id']);
+        }
         if (isset($filters['name'])) {
             $query->where('name', 'like', '%'.$filters['name'].'%');
         }
@@ -32,7 +35,7 @@ class ProductCategoryService
             $query->where('description', 'like', '%'.$filters['description'].'%');
         }
 
-        return $query->paginate($perPage);
+        return $query->with(['establishmentType'])->paginate($perPage);
     }
 
     /**
@@ -43,7 +46,7 @@ class ProductCategoryService
     public function store(array $data): ProductCategory
     {
         try {
-            return ProductCategory::create($data);
+        return ProductCategory::create($data)->load(['establishmentType']);
         } catch (Exception $e) {
             Log::error('Error creating ProductCategory', ['error' => $e->getMessage()]);
             throw $e;
@@ -57,7 +60,7 @@ class ProductCategoryService
      */
     public function show(int $id): ProductCategory
     {
-        return ProductCategory::findOrFail($id);
+        return ProductCategory::with(['establishmentType'])->findOrFail($id);
     }
 
     /**
@@ -71,7 +74,7 @@ class ProductCategoryService
             $category = ProductCategory::findOrFail($id);
             $category->update($data);
 
-            return $category;
+            return $category->load(['establishmentType']);
         } catch (Exception $e) {
             Log::error('Error updating ProductCategory', ['error' => $e->getMessage()]);
             throw $e;

--- a/app/backend/app/Services/ProductCategoryService.php
+++ b/app/backend/app/Services/ProductCategoryService.php
@@ -18,7 +18,7 @@ class ProductCategoryService
     /**
      * Get paginated list of product categories with optional filters.
      */
-    public function index(array $filters, int $perPage = 15): LengthAwarePaginator
+    public function getPaginated(array $filters, int $perPage = 15): LengthAwarePaginator
     {
         $query = ProductCategory::query();
 
@@ -46,7 +46,7 @@ class ProductCategoryService
     public function store(array $data): ProductCategory
     {
         try {
-        return ProductCategory::create($data)->load(['establishmentType']);
+            return ProductCategory::create($data)->load(['establishmentType']);
         } catch (Exception $e) {
             Log::error('Error creating ProductCategory', ['error' => $e->getMessage()]);
             throw $e;

--- a/app/backend/database/factories/CommerceFactory.php
+++ b/app/backend/database/factories/CommerceFactory.php
@@ -30,7 +30,7 @@ class CommerceFactory extends Factory
             'tax_id_type' => $this->faker->randomElement(['NIT', 'CC', 'CE']),
             'address' => $this->faker->address(),
             'phone' => $this->faker->phoneNumber(),
-            'email' => $this->faker->unique()->safeEmail(),
+            'email' => $this->faker->safeEmail(),
             'is_active' => $this->faker->boolean(90),
             'is_verified' => $this->faker->boolean(10),
         ];

--- a/app/backend/database/factories/ProductCategoryFactory.php
+++ b/app/backend/database/factories/ProductCategoryFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Database\Factories;
 
 use App\Constants\Constant;
+use App\Models\EstablishmentType;
 use App\Models\ProductCategory;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -18,6 +19,7 @@ class ProductCategoryFactory extends Factory
     public function definition(): array
     {
         return [
+            'establishment_type_id' => EstablishmentType::factory(),
             'name' => $this->faker->unique()->words(2, true),
             'description' => $this->faker->sentence(6),
             'status' => Constant::STATUS_ACTIVE,

--- a/app/backend/database/factories/ProductCategoryFactory.php
+++ b/app/backend/database/factories/ProductCategoryFactory.php
@@ -20,7 +20,7 @@ class ProductCategoryFactory extends Factory
     {
         return [
             'establishment_type_id' => EstablishmentType::factory(),
-            'name' => $this->faker->unique()->words(2, true),
+            'name' => $this->faker->word(),
             'description' => $this->faker->sentence(6),
             'status' => Constant::STATUS_ACTIVE,
         ];

--- a/app/backend/database/migrations/2026_01_26_000000_create_product_categories_table.php
+++ b/app/backend/database/migrations/2026_01_26_000000_create_product_categories_table.php
@@ -16,11 +16,13 @@ return new class extends Migration
     {
         Schema::create('product_categories', function (Blueprint $table) {
             $table->id();
+            $table->foreignId('establishment_type_id')->nullable()->constrained('establishment_types')->cascadeOnDelete();                
             $table->string('name', 100);
             $table->string('description', 255)->nullable();
             $table->char('status', 1)->default(Constant::STATUS_ACTIVE);
             $table->timestamps();
             $table->softDeletes();
+            $table->index('establishment_type_id');
         });
     }
 

--- a/app/backend/database/migrations/2026_01_26_000000_create_product_categories_table.php
+++ b/app/backend/database/migrations/2026_01_26_000000_create_product_categories_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
     {
         Schema::create('product_categories', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('establishment_type_id')->nullable()->constrained('establishment_types')->cascadeOnDelete();                
+            $table->foreignId('establishment_type_id')->nullable()->constrained('establishment_types')->cascadeOnDelete();
             $table->string('name', 100);
             $table->string('description', 255)->nullable();
             $table->char('status', 1)->default(Constant::STATUS_ACTIVE);

--- a/app/backend/database/seeders/CommerceCommentSeeder.php
+++ b/app/backend/database/seeders/CommerceCommentSeeder.php
@@ -21,7 +21,7 @@ class CommerceCommentSeeder extends Seeder
             // Aquí puedes agregar datos fijos para producción si aplica
         }
         if (env('DEMO_SEEDING') == 'true') {
-            CommerceComment::factory()->count(10)->create();
+            CommerceComment::factory()->count(5)->create();
         }
 
     }

--- a/app/backend/database/seeders/EstablishmentTypeSeeder.php
+++ b/app/backend/database/seeders/EstablishmentTypeSeeder.php
@@ -14,11 +14,8 @@ class EstablishmentTypeSeeder extends Seeder
         if (env('APP_ENV') == 'prd') {
             EstablishmentType::insert([
                 ['name' => 'Restaurante', 'code' => 'RE', 'created_at' => now(), 'updated_at' => now()],
-                ['name' => 'Cafetería', 'code' => 'CA', 'created_at' => now(), 'updated_at' => now()],
-                ['name' => 'Panadería', 'code' => 'PA', 'created_at' => now(), 'updated_at' => now()],
-                ['name' => 'Comida rápida', 'code' => 'CR', 'created_at' => now(), 'updated_at' => now()],
-                ['name' => 'Postres', 'code' => 'PO', 'created_at' => now(), 'updated_at' => now()],
-                ['name' => 'Otro', 'code' => 'OT', 'created_at' => now(), 'updated_at' => now()],
+                ['name' => 'Panadería y Pastelería', 'code' => 'PA', 'created_at' => now(), 'updated_at' => now()],
+                ['name' => 'Retail', 'code' => 'RT', 'created_at' => now(), 'updated_at' => now()],
             ]);
         }
         if (env('DEMO_SEEDING') == 'true') {

--- a/app/backend/database/seeders/ProductCategorySeeder.php
+++ b/app/backend/database/seeders/ProductCategorySeeder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Database\Seeders;
 
+use App\Models\EstablishmentType;
 use App\Models\ProductCategory;
 use Illuminate\Database\Seeder;
 
@@ -16,11 +17,42 @@ class ProductCategorySeeder extends Seeder
     {
         if (env('APP_ENV') == 'prd') {
             ProductCategory::insert([
-                ['name' => 'Cómida rápida', 'description' => 'Hamburguesas, pizzas, tacos, etc.', 'created_at' => now(), 'updated_at' => now()],
-                ['name' => 'Restaurantes', 'description' => 'Lugares donde se sirven comidas completas.', 'created_at' => now(), 'updated_at' => now()],
-                ['name' => 'Postres', 'description' => 'Dulces y postres variados.', 'created_at' => now(), 'updated_at' => now()],
-                ['name' => 'Bebidas', 'description' => 'Bebidas alcohólicas y no alcohólicas.', 'created_at' => now(), 'updated_at' => now()],
-                ['name' => 'Supermercados', 'description' => 'Productos de supermercado y tiendas de conveniencia.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 1, 'name' => 'Plato del día (sopa, seco, principio)', 'description' => 'Almuerzo del día', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 1, 'name' => 'Platos ejecutivos', 'description' => 'Platos especiales', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 1, 'name' => 'Comida rápida (empanadas, arepas, hamburguesas)', 'description' => 'Empanadas, arepas, hamburguesa, pizza.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 1, 'name' => 'Postres y repostería', 'description' => 'Tortas, milhojas, pasteles sin vender en el día.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 1, 'name' => 'Bebidas (café, chocolate, batidos)', 'description' => 'Bebidas calientes (café, chocolate) o frías (batidos).', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 2, 'name' => 'Pan', 'description' => 'Pan de bono, almojábanas, buñuelos, pan de queso.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 2, 'name' => 'Pastelería y repostería', 'description' => 'Tortas, milhojas, roscas, pasteles sin vender.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 2, 'name' => 'Galletas y bizcochos', 'description' => 'Galletas dulces, bizcochos.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 2, 'name' => 'Desayunos preparados (huevos, ensaladas de fruta)', 'description' => 'Huevos preparados, ensaladas de fruta, preparados.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 2, 'name' => 'Bebidas (café, chocolate, batidos)', 'description' => 'Café, chocolate caliente, batidos naturales.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 2, 'name' => 'Postres y dulces', 'description' => 'Postres, dulces, confites frescos del día.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Frutas y verduras', 'description' => 'Frutas con pequeños golpes o formas irregulares.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Frutas y verduras pequeñas', 'description' => 'Verduras ligeramente marchitas o tamaño pequeño.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Frutas y verduras maduras', 'description' => 'Frutas y verduras muy maduras (para jugos, mermeladas).', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Granos (arroz, frijol, lenteja, garbanzo)', 'description' => 'Arroz, frijol, lenteja, garbanzo con vencimiento próximo.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Pastas', 'description' => 'Pastas secas (espagueti, penne, etc.) con vencimiento próximo.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Enlatados (atún, vegetales, salchichas)', 'description' => 'Atún, vegetales, tomate y otros enlatados próximos a vencer.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Encurtidos y salsas', 'description' => 'Encurtidos, salsas, aderezos próximos a vencer.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Aceites y margarinas', 'description' => 'Aceites de cocina, margarinas próximas a vencer.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Condimentos y especias', 'description' => 'Condimentos, especias, sazón próximos a vencer.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Café molido o en grano', 'description' => 'Café molido o en grano próximo a vencer.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Chocolates y bebidas instantáneas', 'description' => 'Chocolates en polvo, bebidas instantáneas próximas a vencer.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Endulzantes', 'description' => 'Endulzantes (azúcar, stevia, otros) próximos a vencer.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Sal', 'description' => 'Sal refinada de mesa próxima a vencer o empaque dañado.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Lácteos (queso, yogur, leche)', 'description' => 'Queso, yogur, leche próximos a la fecha de vencimiento.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Embutidos (jamón, mortadela, salchicha)', 'description' => 'Jamón, mortadela, salchicha próximos a la fecha de vencimiento.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Carnes (Res, cerdo, pollo, pescado)', 'description' => 'Carnes y pollos frescos del día que no se vendieron.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Huevos', 'description' => 'Huevos de descarte estético o próximos a vencer.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Bebidas (Agua, jugos)', 'description' => 'Bebidas gasificadas y semiprocesados.', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Licores', 'description' => 'Cerveza, aguardiente, vino', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Pasabocas (papas, chitos, galletas)', 'description' => 'Dulces próximos a vencer', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Dulcería (caramelos, chicles, chocolates)', 'description' => 'Gomas, cocholaitas, dulces', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Panadería y pastelería', 'description' => 'Mogollas, pan integral, pan blanco', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Aseo para el hogar', 'description' => 'Detergente, suavizantes próximos a vencer', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Cuidado personal e higiene', 'description' => 'Crema dental, cremas, lociones', 'created_at' => now(), 'updated_at' => now()],
+                ['establishment_type_id' => 3, 'name' => 'Mascotas', 'description' => 'Alimento para mascota', 'created_at' => now(), 'updated_at' => now()],
             ]);
         }
         if (env('DEMO_SEEDING') == 'true') {

--- a/app/backend/database/seeders/ProductCategorySeeder.php
+++ b/app/backend/database/seeders/ProductCategorySeeder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Database\Seeders;
 
-use App\Models\EstablishmentType;
 use App\Models\ProductCategory;
 use Illuminate\Database\Seeder;
 

--- a/app/backend/database/seeders/ProductSeeder.php
+++ b/app/backend/database/seeders/ProductSeeder.php
@@ -18,7 +18,7 @@ class ProductSeeder extends Seeder
             // Aquí puedes agregar datos fijos para producción si aplica
         }
         if (env('DEMO_SEEDING') == 'true') {
-            Product::factory()->count(20)->create();
+            Product::factory()->count(5)->create();
         }
     }
 }

--- a/app/backend/tests/Feature/Api/V1/ProductCategoryFeatureTest.php
+++ b/app/backend/tests/Feature/Api/V1/ProductCategoryFeatureTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Api\V1;
 
-use App\Models\ProductCategory;
 use App\Models\EstablishmentType;
+use App\Models\ProductCategory;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Spatie\Permission\Models\Permission;

--- a/app/backend/tests/Feature/Api/V1/ProductCategoryFeatureTest.php
+++ b/app/backend/tests/Feature/Api/V1/ProductCategoryFeatureTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\Api\V1;
 
 use App\Models\ProductCategory;
+use App\Models\EstablishmentType;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Spatie\Permission\Models\Permission;
@@ -50,13 +51,15 @@ class ProductCategoryFeatureTest extends TestCase
     public function test_store_creates_product_category()
     {
         $this->actingAsAdmin();
+        $type = EstablishmentType::factory()->create();
         $payload = [
+            'establishment_type_id' => $type->id,
             'name' => 'Bebidas',
             'description' => 'Bebidas frías y calientes',
         ];
         $response = $this->postJson('/api/v1/product-categories', $payload);
         $response->assertCreated()->assertJsonFragment(['name' => 'Bebidas']);
-        $this->assertDatabaseHas('product_categories', ['name' => 'Bebidas']);
+        $this->assertDatabaseHas('product_categories', ['name' => 'Bebidas', 'establishment_type_id' => $type->id]);
     }
 
     public function test_show_returns_product_category()
@@ -70,11 +73,12 @@ class ProductCategoryFeatureTest extends TestCase
     public function test_update_modifies_product_category()
     {
         $this->actingAsAdmin();
+        $type = EstablishmentType::factory()->create();
         $category = ProductCategory::factory()->create();
-        $payload = ['name' => 'Snacks'];
+        $payload = ['name' => 'Snacks', 'establishment_type_id' => $type->id];
         $response = $this->putJson('/api/v1/product-categories/'.$category->id, $payload);
         $response->assertOk()->assertJsonFragment(['name' => 'Snacks']);
-        $this->assertDatabaseHas('product_categories', ['id' => $category->id, 'name' => 'Snacks']);
+        $this->assertDatabaseHas('product_categories', ['id' => $category->id, 'name' => 'Snacks', 'establishment_type_id' => $type->id]);
     }
 
     public function test_destroy_deletes_product_category()


### PR DESCRIPTION
This pull request introduces support for associating product categories with establishment types throughout the backend API. The main changes include updating the database schema, models, requests, resources, services, and factories to handle the new `establishment_type_id` field and its relationship. Additionally, OpenAPI documentation and validation rules have been updated to reflect these changes.

**Database and Model Changes:**

* Added a nullable `establishment_type_id` foreign key to the `product_categories` table, with an index and cascading deletes. The `ProductCategory` and `EstablishmentType` models now define the appropriate `belongsTo` and `hasMany` relationships. 

**API Request/Response and Validation:**

* Updated `ProductCategoryIndexRequest`, `StoreProductCategoryRequest`, and `UpdateProductCategoryRequest` to include the `establishment_type_id` field, with validation and OpenAPI documentation. 
* The `ProductCategoryResource` now includes `establishment_type_id` and the related `establishment_type` object in its response, with OpenAPI schema updates. 

**Service and Controller Logic:**

* The `ProductCategoryService` and `ProductCategoryController` have been refactored to support filtering, eager loading, and returning the establishment type relationship when listing, creating, showing, and updating product categories

**Factories and Seeders:**

* Updated the `ProductCategoryFactory` to generate an associated `EstablishmentType` for each category, and minor adjustments to other factories and seeders for consistency. 

These changes ensure that product categories can be linked to establishment types, with full API support, validation, and documentation.