### PR TITLE
fix(seeders): restaurar base de datos antes de ejecutar seeders

### DIFF
--- a/app/backend/docker-entrypoint.sh
+++ b/app/backend/docker-entrypoint.sh
@@ -172,6 +172,8 @@ run_seeders() {
     
     # Only run seeders if explicitly enabled
     if [ "$enable_seeding" = "true" ]; then
+        echo "Restoring database from seeders..."
+        php artisan migrate:refresh --force --no-interaction
         echo "Running database seeders..."
         php artisan db:seed --force --no-interaction
     else


### PR DESCRIPTION
This pull request makes a small but important change to the Docker entrypoint script to improve database seeding. Now, when seeding is enabled, the script will first refresh the database migrations before running the seeders, ensuring a clean and consistent database state.

- Database migration refresh before seeding:
  * Updated `run_seeders()` in `app/backend/docker-entrypoint.sh` to run `php artisan migrate:refresh` before seeding, ensuring the database is reset to a known state before applying seed data.