### PR TITLE
fix(audit-log): mejorar la documentación de las respuestas de la API …

### DIFF
--- a/app/backend/app/Http/Controllers/Api/V1/AuditLogController.php
+++ b/app/backend/app/Http/Controllers/Api/V1/AuditLogController.php
@@ -36,16 +36,11 @@ class AuditLogController extends Controller
      *     description="Returns a list of audit logs",
      *     security={{"sanctum":{}}},
      *
-     *     @OA\Response(
-     *         response=200,
-     *         description="Successful operation",
-     *
-     *         @OA\JsonContent(
-     *
+     *     @OA\Response(response=200, description="Successful operation", @OA\JsonContent(type="array", @OA\Items(ref="#/components/schemas/AuditLogResource"))),
      *     @OA\Response(response=401, description="Unauthenticated"),
      *     @OA\Response(response=403, description="Forbidden"),
-     *     @OA\Response(response=429, description="Too many requests, please try again later."),
-     @OA\Response(response=500, description="Internal Server Error")
+     *     @OA\Response(response=429, description="Too Many Requests", @OA\JsonContent(example={"status":false,"message":"Too many requests. Please try again later.","code":429}), @OA\Header(header="Retry-After", description="Segundos hasta que se puede volver a intentar", @OA\Schema(type="integer")), @OA\Header(header="X-RateLimit-Limit", description="Límite de peticiones por ventana", @OA\Schema(type="integer")), @OA\Header(header="X-RateLimit-Remaining", description="Peticiones restantes en la ventana actual", @OA\Schema(type="integer")), @OA\Header(header="X-RateLimit-Reset", description="Timestamp de reseteo de ventana", @OA\Schema(type="integer"))),
+     *     @OA\Response(response=500, description="Internal Server Error")
      * )
      */
     public function index(): JsonResponse
@@ -70,16 +65,13 @@ class AuditLogController extends Controller
      *     description="Returns a single audit log entry",
      *     security={{"sanctum":{}}},
      *
-     *     @OA\Response(
-     *         response=200,
-     *         description="Successful operation",
+     *     @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
      *
-     *         @OA\JsonContent(
-     *
-     *     @OA\Response(response=429, description="Too many requests, please try again later."),
-     *     @OA\Response(response=404, description="Not Found"),
+     *     @OA\Response(response=200, description="Successful operation", @OA\JsonContent(ref="#/components/schemas/AuditLogResource")),
      *     @OA\Response(response=401, description="Unauthenticated"),
-     *     @OA\Response(response=403, description="Forbidden")
+     *     @OA\Response(response=403, description="Forbidden"),
+     *     @OA\Response(response=404, description="Not Found"),
+     *     @OA\Response(response=429, description="Too Many Requests", @OA\JsonContent(example={"status":false,"message":"Too many requests. Please try again later.","code":429}), @OA\Header(header="Retry-After", description="Segundos hasta que se puede volver a intentar", @OA\Schema(type="integer")), @OA\Header(header="X-RateLimit-Limit", description="Límite de peticiones por ventana", @OA\Schema(type="integer")), @OA\Header(header="X-RateLimit-Remaining", description="Peticiones restantes en la ventana actual", @OA\Schema(type="integer")), @OA\Header(header="X-RateLimit-Reset", description="Timestamp de reseteo de ventana", @OA\Schema(type="integer")))
      * )
      */
     public function show(int $id): JsonResponse


### PR DESCRIPTION
This pull request updates the OpenAPI (Swagger) documentation for the `AuditLogController` endpoints to provide more accurate and detailed API responses, especially around rate limiting and response schemas.

OpenAPI documentation improvements:

* Standardized the `200` response for both the `index` and `show` methods to reference the `AuditLogResource` schema, ensuring consistency and clarity in the documented successful responses.
* Enhanced the `429 Too Many Requests` response for both endpoints by including a detailed JSON example and adding rate limiting headers (`Retry-After`, `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`) to help clients handle throttling scenarios more effectively. 
* Added an explicit `id` path parameter definition for the `show` endpoint to clarify required input.
* Included missing `404 Not Found` and reordered response codes for the `show` endpoint for completeness and better API consumer guidance.