### PR TITLE
feat(deploy): support Railway cron command override in entrypoint

### DIFF
--- a/app/backend/docker-entrypoint.sh
+++ b/app/backend/docker-entrypoint.sh
@@ -186,7 +186,21 @@ generate_documentation() {
     php artisan l5-swagger:generate
 }
 
-start_server() {
+is_default_serve_command() {
+    [ "$#" -eq 5 ] && \
+    [ "$1" = "php" ] && \
+    [ "$2" = "artisan" ] && \
+    [ "$3" = "serve" ] && \
+    [ "$4" = "--host=0.0.0.0" ] && \
+    [ "$5" = "--port=8000" ]
+}
+
+start_application() {
+    if [ "$#" -gt 0 ]; then
+        echo "Starting custom command: $*"
+        exec "$@"
+    fi
+
     local port=${PORT:-8000}
     echo "Starting Laravel server on 0.0.0.0:$port..."
     exec php artisan serve --host=0.0.0.0 --port=$port
@@ -210,10 +224,14 @@ main() {
     generate_app_key_if_needed
     ensure_sqlite_file_if_needed
     wait_for_database
-    run_migrations
-    run_seeders
-    generate_documentation
-    start_server
+
+    if [ "$#" -eq 0 ] || is_default_serve_command "$@"; then
+        run_migrations
+        run_seeders
+        generate_documentation
+    fi
+
+    start_application "$@"
 }
 
 main "$@"


### PR DESCRIPTION
## Contexto
Se creó un servicio cron en Railway (sdjr-cron) para ejecutar jobs encolados de correo.  
El backend web y el cron comparten la misma imagen, pero deben arrancar con comportamientos distintos según el comando del servicio.

## Problema
El arranque previo forzaba el flujo de servidor web y podía ignorar el comando custom del servicio cron.

## Solución aplicada
Se actualizó docker-entrypoint.sh para:

- Ejecutar el comando recibido cuando Railway pasa argumentos (por ejemplo: php artisan schedule:run).
- Mantener arranque web por defecto cuando no hay comando custom.
- Ejecutar migraciones/seeders/generación de docs solo en el flujo de arranque web.
- Evitar esas tareas en el flujo cron para no correr trabajo innecesario cada minuto.

## Alcance
- Archivo modificado: docker-entrypoint.sh
- Sin cambios en Dockerfile

## Impacto esperado
- Servicio sdjr: sigue funcionando como backend HTTP.
- Servicio sdjr-cron: ejecuta schedule:run correctamente y procesa cola database (emails/default) sin levantar servidor web.

## Checklist
- [x] Cambio aislado en backend
- [x] Sin mezclar cambios frontend
- [x] Rama basada en main
- [x] Commit enfocado para despliegue Railway cron