### PR TITLE
fix(scheduler): Use schedule:work daemon instead of schedule:run for …

### DIFF
--- a/app/backend/docker-entrypoint.sh
+++ b/app/backend/docker-entrypoint.sh
@@ -209,8 +209,8 @@ start_application() {
     fi
 
     if is_cron_mode; then
-        echo "Cron mode detected, running scheduler once..."
-        exec php artisan schedule:run
+        echo "Cron mode detected, running scheduler daemon..."
+        exec php artisan schedule:work
     fi
 
     local port=${PORT:-8000}


### PR DESCRIPTION
…continuous execution

Con schedule:work, el contenedor se mantiene activo indefinidamente ejecutando el scheduler. Los jobs queued en la tabla jobs serán procesados según las tareas definidas en app/Console/Kernel.php.