### PR TITLE
fix(queue): always register scheduler command and gate execution at r…

### DIFF
--- a/app/backend/routes/console.php
+++ b/app/backend/routes/console.php
@@ -3,12 +3,31 @@
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schedule;
+use Symfony\Component\Console\Command\Command;
+
+$isQueueProcessEnabled = static function (): bool {
+    $rawValue = getenv('QUEUE_PROCESS_ENABLED');
+
+    if ($rawValue === false || $rawValue === '') {
+        $rawValue = env('QUEUE_PROCESS_ENABLED', true);
+    }
+
+    $normalized = filter_var($rawValue, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+    return $normalized ?? true;
+};
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
 
-Artisan::command('queues:process', function () {
+Artisan::command('queues:process', function () use ($isQueueProcessEnabled) {
+    if (! $isQueueProcessEnabled()) {
+        $this->info('Queue processing is disabled via QUEUE_PROCESS_ENABLED.');
+
+        return Command::SUCCESS;
+    }
+
     $queueList = env('QUEUE_PROCESS_QUEUES', 'emails,default');
     $tries = (int) env('QUEUE_PROCESS_TRIES', 3);
     $timeout = (int) env('QUEUE_PROCESS_TIMEOUT', 120);
@@ -23,9 +42,7 @@ Artisan::command('queues:process', function () {
     ]);
 })->purpose('Process queued jobs once and stop when queue is empty');
 
-if (env('QUEUE_PROCESS_ENABLED', true)) {
-    Schedule::command('queues:process')
-        ->everyMinute()
-        ->withoutOverlapping()
-        ->runInBackground();
-}
+Schedule::command('queues:process')
+    ->everyMinute()
+    ->withoutOverlapping()
+    ->runInBackground();


### PR DESCRIPTION
- Ahora queues:process se agenda siempre cada minuto.
- El flag QUEUE_PROCESS_ENABLED se evalúa dentro del comando en runtime.
- Si está deshabilitado, el comando sale limpio con mensaje informativo.
- Se usa parsing booleano robusto para true/false/1/0.