### PR TITLE
fix(entrypoint): add schedule:clear-cache before scheduler in cron mode

### DIFF
--- a/app/backend/docker-entrypoint.sh
+++ b/app/backend/docker-entrypoint.sh
@@ -210,7 +210,9 @@ start_application() {
     fi
 
     if is_cron_mode; then
-        echo "Cron mode detected, running scheduler daemon..."
+        echo "Cron mode detected, clearing scheduler cache..."
+        php artisan schedule:clear-cache
+        echo "Starting scheduler daemon..."
         exec php artisan schedule:work
     fi
 


### PR DESCRIPTION
Wl script ahora ejecuta php artisan schedule:clear-cache antes de iniciar el scheduler en modo cron.