### PR TITLE
feat(notification): add order email notification and fix API permissions/tests

### DIFF
--- a/app/backend/app/Http/Controllers/Api/V1/OrderController.php
+++ b/app/backend/app/Http/Controllers/Api/V1/OrderController.php
@@ -78,12 +78,12 @@ class OrderController extends Controller
      *     operationId="storeOrder",
      *     tags={"Orders"},
      *     summary="Create a new order",
-     *     description="Creates a new order for the authenticated user.",
+     *     description="Creates a new order for the authenticated user. An email notification with order details and products will be sent to the user asynchronously.",
      *     security={{"sanctum":{}}},
      *
      *     @OA\RequestBody(required=true, @OA\JsonContent(ref="#/components/schemas/StoreOrderRequest")),
      *
-     *     @OA\Response(response=201, description="Order created successfully", @OA\JsonContent(type="object", @OA\Property(property="status", type="boolean", example=true), @OA\Property(property="message", type="string", example="Order created successfully"), @OA\Property(property="data", ref="#/components/schemas/OrderResource"))),
+     *     @OA\Response(response=201, description="Order created successfully. An email notification will be sent to the user.", @OA\JsonContent(type="object", @OA\Property(property="status", type="boolean", example=true), @OA\Property(property="message", type="string", example="Order created successfully"), @OA\Property(property="data", ref="#/components/schemas/OrderResource"))),
      *     @OA\Response(response=401, description="Unauthenticated"),
      *     @OA\Response(response=403, description="Forbidden"),
      *     @OA\Response(response=422, description="Unprocessable Entity"),

--- a/app/backend/app/Http/Requests/Api/V1/IndexEstablishmentTypeRequest.php
+++ b/app/backend/app/Http/Requests/Api/V1/IndexEstablishmentTypeRequest.php
@@ -19,7 +19,7 @@ class IndexEstablishmentTypeRequest extends FormRequest
 {
     public function authorize(): bool
     {
-        return $this->user()?->can('provider.establishments.index') ?? false;
+        return $this->user()?->can('provider.establishment_types.index') ?? false;
     }
 
     public function rules(): array

--- a/app/backend/app/Notifications/OrderCreatedNotification.php
+++ b/app/backend/app/Notifications/OrderCreatedNotification.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Models\Order;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+/**
+ * Notification sent when a new order is created.
+ *
+ * @OA\Schema(
+ *     schema="OrderCreatedNotification",
+ *     title="OrderCreatedNotification",
+ *     description="Notification sent to users when they create a new order."
+ * )
+ */
+class OrderCreatedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public Order $order;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(Order $order)
+    {
+        $this->order = $order;
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array<int, string>
+     */
+    public function via($notifiable): array
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Define queue names per channel.
+     *
+     * @return array<string, string>
+     */
+    public function viaQueues(): array
+    {
+        return [
+            'mail' => 'emails',
+        ];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     *
+     * Renders the email using a dedicated Blade view to ensure proper HTML rendering.
+     *
+     * @param  mixed  $notifiable
+     */
+    public function toMail($notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject('¡Tu orden ha sido creada!')
+            ->view('emails.order_created', [
+                'order' => $this->order,
+                'notifiable' => $notifiable,
+                'branchInfo' => $this->getBranchInfo(),
+            ]);
+    }
+
+    /**
+     * Get commerce branch information.
+     *
+     * @return string|null Branch name and address, or null if no branch is associated.
+     */
+    protected function getBranchInfo(): ?string
+    {
+        if (! $this->order->commerceBranch) {
+            return null;
+        }
+
+        $branch = $this->order->commerceBranch;
+        $info = $branch->name ?? $branch->commerce->name ?? 'N/A';
+
+        if (! empty($branch->address)) {
+            $info .= ' - '.$branch->address;
+        }
+
+        return $info;
+    }
+
+    /**
+     * Get the array representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return array<string, mixed>
+     */
+    public function toArray($notifiable): array
+    {
+        return [
+            'order_id' => $this->order->id,
+            'user_id' => $this->order->user_id,
+            'total_price' => $this->order->total_price,
+            'status' => $this->order->status,
+            'message' => 'Nueva orden creada',
+        ];
+    }
+}

--- a/app/backend/app/Services/OrderService.php
+++ b/app/backend/app/Services/OrderService.php
@@ -8,9 +8,12 @@ use App\Constants\Constant;
 use App\Models\Order;
 use App\Models\OrderItem;
 use App\Models\Product;
+use App\Notifications\OrderCreatedNotification;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Notification;
+use Throwable;
 
 class OrderService
 {
@@ -59,7 +62,21 @@ class OrderService
             $order->total_price = round($total, 2);
             $order->save();
 
-            return $order->load('items');
+            // Cargar relaciones necesarias para la notificación
+            $order->load(['items.product', 'user', 'commerceBranch.commerce']);
+
+            // Enviar notificación de orden creada sin bloquear el flujo
+            try {
+                Notification::send($order->user, new OrderCreatedNotification($order));
+            } catch (Throwable $e) {
+                Log::warning('Order created email dispatch failed', [
+                    'order_id' => $order->id,
+                    'user_id' => $order->user_id,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+
+            return $order;
         });
     }
 

--- a/app/backend/database/seeders/RolePermissionSeeder.php
+++ b/app/backend/database/seeders/RolePermissionSeeder.php
@@ -367,6 +367,7 @@ class RolePermissionSeeder extends Seeder
             'admin.params.cities.index',
             'admin.params.neighborhoods.index',
             'admin.legal_documents.index',
+            'provider.establishment_types.index',
             'provider.basic_data.show',
             'provider.branches.show',
             'provider.products.show',

--- a/app/backend/resources/views/emails/order_created.blade.php
+++ b/app/backend/resources/views/emails/order_created.blade.php
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>¡Tu orden ha sido creada!</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+            background-color: #f4f5f7;
+            margin: 0;
+            padding: 0;
+            color: #333333;
+        }
+        .wrapper {
+            max-width: 620px;
+            margin: 40px auto;
+            background-color: #ffffff;
+            border-radius: 8px;
+            overflow: hidden;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+        }
+        .header {
+            background-color: #1a56db;
+            padding: 32px 40px;
+            text-align: center;
+        }
+        .header h1 {
+            color: #ffffff;
+            font-size: 22px;
+            margin: 0;
+            font-weight: 600;
+        }
+        .content {
+            padding: 36px 40px;
+        }
+        .greeting {
+            font-size: 16px;
+            color: #111827;
+            font-weight: 600;
+            margin-bottom: 8px;
+        }
+        .text {
+            font-size: 15px;
+            color: #4b5563;
+            line-height: 1.6;
+            margin-bottom: 12px;
+        }
+        .section-title {
+            font-size: 14px;
+            font-weight: 700;
+            color: #111827;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            margin: 28px 0 12px;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-bottom: 24px;
+            font-size: 14px;
+        }
+        thead tr {
+            background-color: #f3f4f6;
+        }
+        th {
+            border: 1px solid #e5e7eb;
+            padding: 10px 14px;
+            text-align: left;
+            color: #374151;
+            font-weight: 600;
+        }
+        th.center { text-align: center; }
+        th.right  { text-align: right; }
+        td {
+            border: 1px solid #e5e7eb;
+            padding: 10px 14px;
+            color: #4b5563;
+        }
+        td.center { text-align: center; }
+        td.right  { text-align: right; }
+        tbody tr:nth-child(even) {
+            background-color: #f9fafb;
+        }
+        .summary-box {
+            background-color: #f0f4ff;
+            border-left: 4px solid #1a56db;
+            border-radius: 4px;
+            padding: 16px 20px;
+            margin-bottom: 16px;
+        }
+        .summary-box p {
+            margin: 4px 0;
+            font-size: 14px;
+            color: #374151;
+        }
+        .summary-box .total {
+            font-size: 16px;
+            font-weight: 700;
+            color: #111827;
+            margin-top: 8px;
+        }
+        .status-badge {
+            display: inline-block;
+            padding: 4px 12px;
+            border-radius: 9999px;
+            font-size: 13px;
+            font-weight: 600;
+            background-color: #dbeafe;
+            color: #1e40af;
+        }
+        .footer {
+            background-color: #f9fafb;
+            border-top: 1px solid #e5e7eb;
+            padding: 24px 40px;
+            text-align: center;
+            font-size: 13px;
+            color: #9ca3af;
+        }
+    </style>
+</head>
+<body>
+    <div class="wrapper">
+        <!-- Header -->
+        <div class="header">
+            <h1>¡Tu orden ha sido creada!</h1>
+        </div>
+
+        <!-- Body -->
+        <div class="content">
+            <p class="greeting">Hola {{ $notifiable->name }},</p>
+            <p class="text">Tu orden <strong>#{{ $order->id }}</strong> ha sido creada exitosamente.</p>
+            <p class="text">A continuación encontrarás los detalles de tu pedido:</p>
+
+            <!-- Products Table -->
+            <p class="section-title">Productos</p>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Producto</th>
+                        <th class="center">Cantidad</th>
+                        <th class="right">Precio Unit.</th>
+                        <th class="right">Subtotal</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($order->items as $item)
+                        <tr>
+                            <td>{{ $item->product->title }}</td>
+                            <td class="center">{{ $item->quantity }}</td>
+                            <td class="right">${{ number_format($item->unit_price, 2) }}</td>
+                            <td class="right">${{ number_format($item->subtotal, 2) }}</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+
+            <!-- Summary -->
+            <div class="summary-box">
+                @if ($branchInfo)
+                    <p><strong>Sucursal:</strong> {{ $branchInfo }}</p>
+                @endif
+                <p><strong>Estado:</strong> <span class="status-badge">{{ $order->status }}</span></p>
+                <p class="total">Total: ${{ number_format($order->total_price, 2) }}</p>
+            </div>
+
+            <p class="text">¡Gracias por tu compra!</p>
+        </div>
+
+        <!-- Footer -->
+        <div class="footer">
+            <p>Este correo fue enviado automáticamente. Por favor no respondas a este mensaje.</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/app/backend/tests/Feature/Api/V1/EstablishmentTypeTest.php
+++ b/app/backend/tests/Feature/Api/V1/EstablishmentTypeTest.php
@@ -19,10 +19,26 @@ class EstablishmentTypeTest extends TestCase
     {
         parent::setUp();
         // Crear permisos necesarios con guard sanctum
+        Permission::findOrCreate('provider.establishment_types.index', 'sanctum');
         Permission::findOrCreate('provider.establishment_types.create', 'sanctum');
         Permission::findOrCreate('provider.establishment_types.update', 'sanctum');
         Permission::findOrCreate('provider.establishment_types.show', 'sanctum');
         Permission::findOrCreate('provider.establishment_types.delete', 'sanctum');
+    }
+
+    /**
+     * Prueba que un usuario con permiso puede listar los tipos de establecimiento.
+     */
+    public function test_user_can_list_establishment_types()
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('provider.establishment_types.index');
+        $this->actingAs($user, 'sanctum');
+
+        EstablishmentType::factory()->count(3)->create();
+        $response = $this->getJson('/api/v1/establishment-types');
+        $response->assertOk();
+        $response->assertJsonCount(3, 'data');
     }
 
     /**

--- a/app/backend/tests/Feature/Api/V1/OrderFeatureTest.php
+++ b/app/backend/tests/Feature/Api/V1/OrderFeatureTest.php
@@ -9,7 +9,9 @@ use App\Models\CommerceBranch;
 use App\Models\Order;
 use App\Models\Product;
 use App\Models\User;
+use App\Notifications\OrderCreatedNotification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
 use Laravel\Sanctum\Sanctum;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
@@ -276,5 +278,50 @@ class OrderFeatureTest extends TestCase
         ]);
 
         $response->assertUnauthorized();
+    }
+
+    public function test_customer_creates_order_and_receives_notification(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+        $user->assignRole('user');
+        $user->givePermissionTo('customer.orders.create');
+        Sanctum::actingAs($user);
+
+        $branch = CommerceBranch::factory()->create();
+        $products = Product::factory()->count(2)->create(['commerce_id' => $branch->commerce_id]);
+
+        $body = [
+            'commerce_branch_id' => $branch->id,
+            'items' => [
+                [
+                    'product_id' => $products[0]->id,
+                    'quantity' => 2,
+                ],
+                [
+                    'product_id' => $products[1]->id,
+                    'quantity' => 1,
+                ],
+            ],
+        ];
+
+        $response = $this->postJson('/api/v1/orders', $body);
+
+        $response->assertCreated();
+        $response->assertJsonPath('status', true);
+        $response->assertJsonPath('message', 'Order created successfully');
+
+        // Verificar que se envió la notificación
+        Notification::assertSentTo(
+            $user,
+            OrderCreatedNotification::class,
+            function ($notification, $channels) {
+                $order = Order::latest('id')->first();
+
+                return $notification->order->id === $order->id
+                    && in_array('mail', $channels);
+            }
+        );
     }
 }

--- a/app/backend/tests/Feature/Api/V1/ThrottleAuthTest.php
+++ b/app/backend/tests/Feature/Api/V1/ThrottleAuthTest.php
@@ -2,28 +2,28 @@
 
 declare(strict_types=1);
 
-namespace Tests\Feature;
+namespace Tests\Feature\Api\V1;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Str;
 use Tests\TestCase;
 
-class ThrottlePasswordResetTest extends TestCase
+class ThrottleAuthTest extends TestCase
 {
     use RefreshDatabase;
 
     /**
-     * Test password forgot endpoint throttling (should return 429 after 10 requests/min).
+     * Test login endpoint throttling (should return 429 after 10 requests/min).
      */
-    public function test_password_forgot_throttle_returns_429_after_limit(): void
+    public function test_login_throttle_returns_429_after_limit(): void
     {
         $payload = [
-            'email' => Str::random(10).'@example.com',
+            'email' => 'test@example.com',
+            'password' => 'wrongpassword',
         ];
         for ($i = 0; $i < 10; $i++) {
-            $this->postJson('/api/v1/password/forgot', $payload);
+            $this->postJson('/api/v1/login', $payload);
         }
-        $response = $this->postJson('/api/v1/password/forgot', $payload);
+        $response = $this->postJson('/api/v1/login', $payload);
         $response->assertStatus(429)
             ->assertJson([
                 'status' => false,
@@ -36,20 +36,14 @@ class ThrottlePasswordResetTest extends TestCase
     }
 
     /**
-     * Test password reset endpoint throttling (should return 429 after 10 requests/min).
+     * Test nearby branches endpoint throttling (should return 429 after 60 requests/min).
      */
-    public function test_password_reset_throttle_returns_429_after_limit(): void
+    public function test_nearby_branches_throttle_returns_429_after_limit(): void
     {
-        $payload = [
-            'email' => Str::random(10).'@example.com',
-            'token' => Str::random(32),
-            'password' => 'password',
-            'password_confirmation' => 'password',
-        ];
-        for ($i = 0; $i < 10; $i++) {
-            $this->postJson('/api/v1/password/reset', $payload);
+        for ($i = 0; $i < 60; $i++) {
+            $this->getJson('/api/v1/nearby/branches?lat=4.7&lng=-74.0');
         }
-        $response = $this->postJson('/api/v1/password/reset', $payload);
+        $response = $this->getJson('/api/v1/nearby/branches?lat=4.7&lng=-74.0');
         $response->assertStatus(429)
             ->assertJson([
                 'status' => false,

--- a/app/backend/tests/Feature/Api/V1/ThrottleAuthenticatedTest.php
+++ b/app/backend/tests/Feature/Api/V1/ThrottleAuthenticatedTest.php
@@ -2,32 +2,28 @@
 
 declare(strict_types=1);
 
-namespace Tests\Feature;
+namespace Tests\Feature\Api\V1;
 
-use App\Models\Order;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
 use Tests\TestCase;
 
-class ThrottleOrderCreateTest extends TestCase
+class ThrottleAuthenticatedTest extends TestCase
 {
     use RefreshDatabase;
 
     /**
-     * Test order creation endpoint throttling (should return 429 after 100 requests/min).
+     * Test authenticated user throttle (should return 429 after 100 requests/min).
      */
-    public function test_order_create_throttle_returns_429_after_limit(): void
+    public function test_authenticated_throttle_returns_429_after_limit(): void
     {
         $user = User::factory()->create();
         Sanctum::actingAs($user);
-        $payload = [
-            // Completa con los campos mínimos requeridos por Order
-        ];
         for ($i = 0; $i < 100; $i++) {
-            $this->postJson('/api/v1/orders', $payload);
+            $this->getJson('/api/v1/me');
         }
-        $response = $this->postJson('/api/v1/orders', $payload);
+        $response = $this->getJson('/api/v1/me');
         $response->assertStatus(429)
             ->assertJson([
                 'status' => false,

--- a/app/backend/tests/Feature/Api/V1/ThrottleCustomerRegisterTest.php
+++ b/app/backend/tests/Feature/Api/V1/ThrottleCustomerRegisterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Feature;
+namespace Tests\Feature\Api\V1;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;

--- a/app/backend/tests/Feature/Api/V1/ThrottleOrderCreateTest.php
+++ b/app/backend/tests/Feature/Api/V1/ThrottleOrderCreateTest.php
@@ -2,28 +2,31 @@
 
 declare(strict_types=1);
 
-namespace Tests\Feature;
+namespace Tests\Feature\Api\V1;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
 use Tests\TestCase;
 
-class ThrottleAuthenticatedTest extends TestCase
+class ThrottleOrderCreateTest extends TestCase
 {
     use RefreshDatabase;
 
     /**
-     * Test authenticated user throttle (should return 429 after 100 requests/min).
+     * Test order creation endpoint throttling (should return 429 after 100 requests/min).
      */
-    public function test_authenticated_throttle_returns_429_after_limit(): void
+    public function test_order_create_throttle_returns_429_after_limit(): void
     {
         $user = User::factory()->create();
         Sanctum::actingAs($user);
+        $payload = [
+            // Completa con los campos mínimos requeridos por Order
+        ];
         for ($i = 0; $i < 100; $i++) {
-            $this->getJson('/api/v1/me');
+            $this->postJson('/api/v1/orders', $payload);
         }
-        $response = $this->getJson('/api/v1/me');
+        $response = $this->postJson('/api/v1/orders', $payload);
         $response->assertStatus(429)
             ->assertJson([
                 'status' => false,

--- a/app/backend/tests/Feature/Api/V1/ThrottlePasswordResetTest.php
+++ b/app/backend/tests/Feature/Api/V1/ThrottlePasswordResetTest.php
@@ -2,28 +2,28 @@
 
 declare(strict_types=1);
 
-namespace Tests\Feature;
+namespace Tests\Feature\Api\V1;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
 use Tests\TestCase;
 
-class ThrottleAuthTest extends TestCase
+class ThrottlePasswordResetTest extends TestCase
 {
     use RefreshDatabase;
 
     /**
-     * Test login endpoint throttling (should return 429 after 10 requests/min).
+     * Test password forgot endpoint throttling (should return 429 after 10 requests/min).
      */
-    public function test_login_throttle_returns_429_after_limit(): void
+    public function test_password_forgot_throttle_returns_429_after_limit(): void
     {
         $payload = [
-            'email' => 'test@example.com',
-            'password' => 'wrongpassword',
+            'email' => Str::random(10).'@example.com',
         ];
         for ($i = 0; $i < 10; $i++) {
-            $this->postJson('/api/v1/login', $payload);
+            $this->postJson('/api/v1/password/forgot', $payload);
         }
-        $response = $this->postJson('/api/v1/login', $payload);
+        $response = $this->postJson('/api/v1/password/forgot', $payload);
         $response->assertStatus(429)
             ->assertJson([
                 'status' => false,
@@ -36,14 +36,20 @@ class ThrottleAuthTest extends TestCase
     }
 
     /**
-     * Test nearby branches endpoint throttling (should return 429 after 60 requests/min).
+     * Test password reset endpoint throttling (should return 429 after 10 requests/min).
      */
-    public function test_nearby_branches_throttle_returns_429_after_limit(): void
+    public function test_password_reset_throttle_returns_429_after_limit(): void
     {
-        for ($i = 0; $i < 60; $i++) {
-            $this->getJson('/api/v1/nearby/branches?lat=4.7&lng=-74.0');
+        $payload = [
+            'email' => Str::random(10).'@example.com',
+            'token' => Str::random(32),
+            'password' => 'password',
+            'password_confirmation' => 'password',
+        ];
+        for ($i = 0; $i < 10; $i++) {
+            $this->postJson('/api/v1/password/reset', $payload);
         }
-        $response = $this->getJson('/api/v1/nearby/branches?lat=4.7&lng=-74.0');
+        $response = $this->postJson('/api/v1/password/reset', $payload);
         $response->assertStatus(429)
             ->assertJson([
                 'status' => false,

--- a/app/backend/tests/Feature/Api/V1/ThrottleRegisterTest.php
+++ b/app/backend/tests/Feature/Api/V1/ThrottleRegisterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Feature;
+namespace Tests\Feature\Api\V1;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;

--- a/app/backend/tests/Unit/Api/V1/Notifications/NotificationQueueTest.php
+++ b/app/backend/tests/Unit/Api/V1/Notifications/NotificationQueueTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Notifications;
+namespace Tests\Unit\Api\V1\Notifications;
 
 use App\Models\Commerce;
 use App\Models\User;

--- a/app/backend/tests/Unit/Api/V1/Notifications/OrderCreatedNotificationTest.php
+++ b/app/backend/tests/Unit/Api/V1/Notifications/OrderCreatedNotificationTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Api\V1\Notifications;
+
+use App\Models\CommerceBranch;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Product;
+use App\Models\User;
+use App\Notifications\OrderCreatedNotification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Tests\TestCase;
+
+class OrderCreatedNotificationTest extends TestCase
+{
+    public function test_order_created_notification_uses_queue_and_mail_channel(): void
+    {
+        $order = new Order([
+            'id' => 1,
+            'user_id' => 1,
+            'commerce_branch_id' => 1,
+            'total_price' => 100.00,
+            'status' => 'pending',
+        ]);
+        $order->id = 1;
+
+        $user = new User([
+            'name' => 'Cliente',
+            'email' => 'cliente@test.com',
+        ]);
+
+        $notification = new OrderCreatedNotification($order);
+
+        $this->assertInstanceOf(ShouldQueue::class, $notification);
+        $this->assertSame(['mail'], $notification->via($user));
+        $this->assertSame(['mail' => 'emails'], $notification->viaQueues());
+    }
+
+    public function test_order_created_notification_mail_content(): void
+    {
+        $user = new User([
+            'name' => 'Cliente Test',
+            'email' => 'cliente@test.com',
+        ]);
+
+        $branch = new CommerceBranch([
+            'name' => 'Sucursal Centro',
+        ]);
+        $branch->id = 1;
+
+        $order = new Order([
+            'id' => 123,
+            'user_id' => 1,
+            'commerce_branch_id' => 1,
+            'total_price' => 150.50,
+            'status' => 'pending',
+        ]);
+        $order->id = 123;
+        $order->setRelation('commerceBranch', $branch);
+
+        $product = new Product([
+            'title' => 'Producto Test',
+        ]);
+
+        $item = new OrderItem([
+            'order_id' => 123,
+            'product_id' => 1,
+            'quantity' => 2,
+            'unit_price' => 75.25,
+        ]);
+        $item->setRelation('product', $product);
+
+        $order->setRelation('items', collect([$item]));
+
+        $notification = new OrderCreatedNotification($order);
+
+        $mail = $notification->toMail($user);
+
+        // Subject and type
+        $this->assertInstanceOf(MailMessage::class, $mail);
+        $this->assertSame('¡Tu orden ha sido creada!', $mail->subject);
+
+        // Uses a Blade view (not the fluent ->line() API)
+        $this->assertSame('emails.order_created', $mail->view);
+
+        // View data contains the required variables
+        $this->assertArrayHasKey('order', $mail->viewData);
+        $this->assertArrayHasKey('notifiable', $mail->viewData);
+        $this->assertArrayHasKey('branchInfo', $mail->viewData);
+
+        // View data values are correct
+        $this->assertSame($order, $mail->viewData['order']);
+        $this->assertSame($user, $mail->viewData['notifiable']);
+        $this->assertSame('Sucursal centro', $mail->viewData['branchInfo']);
+
+        // Rendered HTML contains expected content
+        $html = view($mail->view, $mail->viewData)->render();
+        $this->assertStringContainsString('Cliente Test', $html);
+        $this->assertStringContainsString('#123', $html);
+        $this->assertStringContainsString('Producto Test', $html);
+        $this->assertStringContainsString('150.50', $html);
+        $this->assertStringContainsString('Sucursal centro', $html);
+        $this->assertStringContainsString('pending', $html);
+    }
+
+    public function test_order_created_notification_to_array(): void
+    {
+        $order = new Order([
+            'id' => 456,
+            'user_id' => 2,
+            'commerce_branch_id' => 1,
+            'total_price' => 200.00,
+            'status' => 'pending',
+        ]);
+        $order->id = 456;
+
+        $user = new User([
+            'name' => 'Usuario',
+            'email' => 'usuario@test.com',
+        ]);
+
+        $notification = new OrderCreatedNotification($order);
+
+        $arrayData = $notification->toArray($user);
+
+        $this->assertSame(456, $arrayData['order_id']);
+        $this->assertSame(2, $arrayData['user_id']);
+        $this->assertSame(200.00, $arrayData['total_price']);
+        $this->assertSame('pending', $arrayData['status']);
+        $this->assertSame('Nueva orden creada', $arrayData['message']);
+    }
+}


### PR DESCRIPTION
## Summary
- add queued email notification when a customer creates an order
- update Swagger and email template for the new order notification flow
- fix establishment type listing permission and add missing permission seeding
- move throttle tests to Api\/V1 namespaces and add notification coverage

## Included commits
- feat(notification): agregar notificación por correo al crear una nueva orden y mejorar la documentación
- test(throttle): cambio de namespaces para los endpoints throttle de la API
- fix(permissions): actualizar permisos para el listado de tipos de establecimiento