### PR TITLE
Jerson/fixes

### DIFF
--- a/.opencode/plans/productPackageItemsQuantity.prompt.md
+++ b/.opencode/plans/productPackageItemsQuantity.prompt.md
@@ -13,7 +13,8 @@ Se agregará el campo `quantity` (unsignedInteger) a la tabla intermedia `produc
    1. Actualizar validaciones en StoreProductRequest cambiando de `package_items.*` (integer) a estructura de objetos con `package_items.*.product_id` y `package_items.*.quantity` (required, integer, min:1).
    2. Actualizar validaciones en UpdateProductRequest con misma estructura.
    3. Agregar regla `distinct` en `product_id` para prevenir productos duplicados en el mismo paquete.
-   4. Actualizar documentación Swagger en ambos Request con esquema de objeto que incluya `product_id` y `quantity`, incluyendo ejemplos.
+   4. Agregar validación personalizada con `withValidator` para verificar que `quantity` no exceda `quantity_available` del producto.
+   5. Actualizar documentación Swagger en ambos Request con esquema de objeto que incluya `product_id` y `quantity`, incluyendo ejemplos.
 
 3. Fase de lógica de negocio
    1. Modificar ProductService::storePackageItems transformando array de items antes de `attach()` para incluir quantity en pivot.
@@ -31,6 +32,8 @@ Se agregará el campo `quantity` (unsignedInteger) a la tabla intermedia `produc
       - `test_store_package_items_rejects_negative_quantity()`
       - `test_update_package_items_updates_quantity()`
       - `test_store_package_items_prevents_duplicate_products()`
+      - `test_store_package_items_rejects_quantity_exceeding_available()`
+      - `test_update_package_items_rejects_quantity_exceeding_available()`
 
 5. Fase de verificación
    1. Ejecutar suite completa de tests: `php artisan test`
@@ -42,19 +45,20 @@ Se agregará el campo `quantity` (unsignedInteger) a la tabla intermedia `produc
 - [app/backend/database/migrations/YYYY_MM_DD_add_quantity_to_product_package_items_table.php](app/backend/database/migrations/) - nueva migración para agregar columna quantity (CREAR).
 - [app/backend/app/Models/Product.php](app/backend/app/Models/Product.php) - agregar `withPivot('quantity')` en líneas 131-134 y 141-144.
 - [app/backend/app/Services/ProductService.php](app/backend/app/Services/ProductService.php) - transformar datos en `storePackageItems` (~línea 285) y `updatePackageItems` (~línea 309).
-- [app/backend/app/Http/Requests/Api/V1/StoreProductRequest.php](app/backend/app/Http/Requests/Api/V1/StoreProductRequest.php) - actualizar validaciones (línea ~91) y documentación Swagger (líneas 42-47).
-- [app/backend/app/Http/Requests/Api/V1/UpdateProductRequest.php](app/backend/app/Http/Requests/Api/V1/UpdateProductRequest.php) - actualizar validaciones (línea ~82).
+- [app/backend/app/Http/Requests/Api/V1/StoreProductRequest.php](app/backend/app/Http/Requests/Api/V1/StoreProductRequest.php) - actualizar validaciones (línea ~91), agregar método `withValidator` para validar quantity vs quantity_available, y documentación Swagger (líneas 42-47).
+- [app/backend/app/Http/Requests/Api/V1/UpdateProductRequest.php](app/backend/app/Http/Requests/Api/V1/UpdateProductRequest.php) - actualizar validaciones (línea ~82) y agregar método `withValidator` para validar quantity vs quantity_available.
 - [app/backend/app/Http/Resources/Api/V1/ProductResource.php](app/backend/app/Http/Resources/Api/V1/ProductResource.php) - incluir `pivot->quantity` en packageItems.
-- [app/backend/tests/Feature/Api/V1/ProductFeatureTest.php](app/backend/tests/Feature/Api/V1/ProductFeatureTest.php) - actualizar tests existentes (líneas 178-290) y crear 5 nuevos tests.
+- [app/backend/tests/Feature/Api/V1/ProductFeatureTest.php](app/backend/tests/Feature/Api/V1/ProductFeatureTest.php) - actualizar tests existentes (líneas 178-290) y crear 7 nuevos tests.
 
 **Verification**
 1. Confirmar columna `quantity` existe en tabla `product_package_items` tras migración.
 2. Probar crear paquete con nuevo formato y validar persistencia en DB con quantity correcto.
 3. Probar actualizar paquete y validar que quantity se actualiza correctamente.
 4. Probar validaciones: quantity requerido (422), quantity = 0 (422), quantity negativo (422).
-5. Probar productos duplicados en mismo request y esperar 422.
-6. Validar respuestas GET incluyan campo quantity en cada item del paquete.
-7. Ejecutar suite completa de tests y confirmar 100% pasan.
+5. Probar que quantity no puede exceder quantity_available del producto (422).
+6. Probar productos duplicados en mismo request y esperar 422.
+7. Validar respuestas GET incluyan campo quantity en cada item del paquete.
+8. Ejecutar suite completa de tests y confirmar 100% pasan.
 
 **Decisions**
 - Tipo de dato: `unsignedInteger` (solo enteros, no decimales) - confirmado por usuario.
@@ -63,6 +67,7 @@ Se agregará el campo `quantity` (unsignedInteger) a la tabla intermedia `produc
 - Breaking change: Implementar cambio directo sin compatibilidad temporal - confirmado por usuario.
 - Valor default: `default(1)` en migración como fallback.
 - Validación adicional: `distinct` para prevenir duplicados en mismo request.
+- Validación de negocio: `quantity` no puede exceder `quantity_available` del producto - implementado con `withValidator`.
 - Estructura request: De `package_items: [1, 2, 3]` a `package_items: [{product_id: 1, quantity: 2}, ...]`
 - Estructura response: Incluir `quantity` en cada item de packageItems.
 

--- a/.opencode/plans/productPackageItemsQuantity.prompt.md
+++ b/.opencode/plans/productPackageItemsQuantity.prompt.md
@@ -1,0 +1,82 @@
+## Plan: Agregar Campo Quantity a Product Package Items
+
+Se agregará el campo `quantity` (unsignedInteger) a la tabla intermedia `product_package_items` para especificar cuántas unidades de cada producto contiene un paquete. Este cambio implica un breaking change en el API, modificando la estructura de `package_items` de un array de IDs a un array de objetos con `product_id` y `quantity`.
+
+**Steps**
+
+1. Fase de base de datos
+   1. Crear migración `add_quantity_to_product_package_items_table` agregando columna `quantity` (unsignedInteger, default: 1).
+   2. Ejecutar migración en ambiente local.
+   3. Actualizar relaciones en modelo Product agregando `->withPivot('quantity')` en métodos `packageItems()` y `package()`.
+
+2. Fase de validación y contratos
+   1. Actualizar validaciones en StoreProductRequest cambiando de `package_items.*` (integer) a estructura de objetos con `package_items.*.product_id` y `package_items.*.quantity` (required, integer, min:1).
+   2. Actualizar validaciones en UpdateProductRequest con misma estructura.
+   3. Agregar regla `distinct` en `product_id` para prevenir productos duplicados en el mismo paquete.
+   4. Actualizar documentación Swagger en ambos Request con esquema de objeto que incluya `product_id` y `quantity`, incluyendo ejemplos.
+
+3. Fase de lógica de negocio
+   1. Modificar ProductService::storePackageItems transformando array de items antes de `attach()` para incluir quantity en pivot.
+   2. Modificar ProductService::updatePackageItems con misma transformación.
+   3. Actualizar ProductResource para incluir `quantity` del pivot en respuestas de `packageItems`.
+
+4. Fase de pruebas
+   1. Actualizar tests existentes modificando estructura de datos de prueba para incluir `product_id` y `quantity`:
+      - `test_delete_package_items_deletes_all()`
+      - `test_get_package_items_returns_items()`
+      - `test_get_package_items_returns_empty_when_none()`
+   2. Crear nuevos tests de validación:
+      - `test_store_package_items_requires_quantity()`
+      - `test_store_package_items_rejects_zero_quantity()`
+      - `test_store_package_items_rejects_negative_quantity()`
+      - `test_update_package_items_updates_quantity()`
+      - `test_store_package_items_prevents_duplicate_products()`
+
+5. Fase de verificación
+   1. Ejecutar suite completa de tests: `php artisan test`
+   2. Regenerar documentación Swagger si aplica
+   3. Probar manualmente con Postman/Insomnia todos los endpoints de package items
+   4. Validar respuestas incluyan campo quantity correctamente
+
+**Relevant files**
+- [app/backend/database/migrations/YYYY_MM_DD_add_quantity_to_product_package_items_table.php](app/backend/database/migrations/) - nueva migración para agregar columna quantity (CREAR).
+- [app/backend/app/Models/Product.php](app/backend/app/Models/Product.php) - agregar `withPivot('quantity')` en líneas 131-134 y 141-144.
+- [app/backend/app/Services/ProductService.php](app/backend/app/Services/ProductService.php) - transformar datos en `storePackageItems` (~línea 285) y `updatePackageItems` (~línea 309).
+- [app/backend/app/Http/Requests/Api/V1/StoreProductRequest.php](app/backend/app/Http/Requests/Api/V1/StoreProductRequest.php) - actualizar validaciones (línea ~91) y documentación Swagger (líneas 42-47).
+- [app/backend/app/Http/Requests/Api/V1/UpdateProductRequest.php](app/backend/app/Http/Requests/Api/V1/UpdateProductRequest.php) - actualizar validaciones (línea ~82).
+- [app/backend/app/Http/Resources/Api/V1/ProductResource.php](app/backend/app/Http/Resources/Api/V1/ProductResource.php) - incluir `pivot->quantity` en packageItems.
+- [app/backend/tests/Feature/Api/V1/ProductFeatureTest.php](app/backend/tests/Feature/Api/V1/ProductFeatureTest.php) - actualizar tests existentes (líneas 178-290) y crear 5 nuevos tests.
+
+**Verification**
+1. Confirmar columna `quantity` existe en tabla `product_package_items` tras migración.
+2. Probar crear paquete con nuevo formato y validar persistencia en DB con quantity correcto.
+3. Probar actualizar paquete y validar que quantity se actualiza correctamente.
+4. Probar validaciones: quantity requerido (422), quantity = 0 (422), quantity negativo (422).
+5. Probar productos duplicados en mismo request y esperar 422.
+6. Validar respuestas GET incluyan campo quantity en cada item del paquete.
+7. Ejecutar suite completa de tests y confirmar 100% pasan.
+
+**Decisions**
+- Tipo de dato: `unsignedInteger` (solo enteros, no decimales) - confirmado por usuario.
+- Valor mínimo: 1 unidad (no permitir 0) - confirmado por usuario.
+- Datos existentes: No hay paquetes en BD, no requiere migración de datos - confirmado por usuario.
+- Breaking change: Implementar cambio directo sin compatibilidad temporal - confirmado por usuario.
+- Valor default: `default(1)` en migración como fallback.
+- Validación adicional: `distinct` para prevenir duplicados en mismo request.
+- Estructura request: De `package_items: [1, 2, 3]` a `package_items: [{product_id: 1, quantity: 2}, ...]`
+- Estructura response: Incluir `quantity` en cada item de packageItems.
+
+**Breaking Changes**
+⚠️ Este cambio rompe compatibilidad con clientes existentes del API:
+- **Antes**: `POST /api/v1/products/commerce/package-items` con `package_items: [1, 2, 3]`
+- **Después**: `POST /api/v1/products/commerce/package-items` con `package_items: [{product_id: 1, quantity: 2}, ...]`
+- **Impacto**: Todos los consumidores del API deben actualizar sus requests al crear/actualizar paquetes.
+- **Notificación**: Se debe comunicar este breaking change a todos los equipos que consuman estos endpoints.
+
+**Estimated Time**: ~2.5 horas total
+- Migración y modelos: 15 min
+- Servicios y validadores: 30 min
+- Documentación Swagger: 20 min
+- Resources: 15 min
+- Tests: 45 min
+- Testing manual y ajustes: 30 min

--- a/app/backend/app/Http/Requests/Api/V1/StoreProductRequest.php
+++ b/app/backend/app/Http/Requests/Api/V1/StoreProductRequest.php
@@ -6,7 +6,9 @@ namespace App\Http\Requests\Api\V1;
 
 use App\Constants\Constant;
 use App\Models\Commerce;
+use App\Models\Product;
 use App\Services\ProductService;
+use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -110,5 +112,29 @@ class StoreProductRequest extends FormRequest
             'package_items.*.product_id' => ['required', 'integer', 'exists:products,id', 'distinct'],
             'package_items.*.quantity' => ['required', 'integer', 'min:1'],
         ];
+    }
+
+    /**
+     * Configure the validator instance.
+     */
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function ($validator) {
+            if ($this->has('package_items')) {
+                foreach ($this->input('package_items', []) as $index => $item) {
+                    if (isset($item['product_id']) && isset($item['quantity'])) {
+                        $product = Product::find($item['product_id']);
+                        if ($product) {
+                            if ($item['quantity'] > $product->quantity_available) {
+                                $validator->errors()->add(
+                                    "package_items.{$index}.quantity",
+                                    "The quantity cannot exceed the available quantity ({$product->quantity_available}) of product '{$product->title}'."
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        });
     }
 }

--- a/app/backend/app/Http/Requests/Api/V1/StoreProductRequest.php
+++ b/app/backend/app/Http/Requests/Api/V1/StoreProductRequest.php
@@ -42,8 +42,26 @@ use Illuminate\Foundation\Http\FormRequest;
  *   @OA\Property(
  *     property="package_items",
  *     type="array",
+ *     description="Array of products included in this package",
  *
- *     @OA\Items(type="integer", example=10, description="ID of a product included in the package")
+ *     @OA\Items(
+ *       type="object",
+ *       required={"product_id", "quantity"},
+ *
+ *       @OA\Property(
+ *         property="product_id",
+ *         type="integer",
+ *         example=10,
+ *         description="ID of the product to include"
+ *       ),
+ *       @OA\Property(
+ *         property="quantity",
+ *         type="integer",
+ *         minimum=1,
+ *         example=2,
+ *         description="Quantity of this product in the package"
+ *       )
+ *     )
  *   )
  * )
  */
@@ -88,7 +106,9 @@ class StoreProductRequest extends FormRequest
             'photos.*.metadata' => ['nullable', 'array'],
 
             // Package
-            'package_items.*' => ['sometimes', 'integer', 'exists:products,id'],
+            'package_items' => ['sometimes', 'array'],
+            'package_items.*.product_id' => ['required', 'integer', 'exists:products,id', 'distinct'],
+            'package_items.*.quantity' => ['required', 'integer', 'min:1'],
         ];
     }
 }

--- a/app/backend/app/Http/Requests/Api/V1/UpdateProductRequest.php
+++ b/app/backend/app/Http/Requests/Api/V1/UpdateProductRequest.php
@@ -39,8 +39,26 @@ use Illuminate\Foundation\Http\FormRequest;
  *   @OA\Property(
  *     property="package_items",
  *     type="array",
+ *     description="Array of products included in this package",
  *
- *     @OA\Items(type="integer", example=10, description="ID of a product included in the package")
+ *     @OA\Items(
+ *       type="object",
+ *       required={"product_id", "quantity"},
+ *
+ *       @OA\Property(
+ *         property="product_id",
+ *         type="integer",
+ *         example=10,
+ *         description="ID of the product to include"
+ *       ),
+ *       @OA\Property(
+ *         property="quantity",
+ *         type="integer",
+ *         minimum=1,
+ *         example=2,
+ *         description="Quantity of this product in the package"
+ *       )
+ *     )
  *   )
  * )
  */
@@ -79,7 +97,9 @@ class UpdateProductRequest extends FormRequest
             // Fotos
 
             // Package
-            'package_items.*' => ['sometimes', 'integer', 'exists:products,id'],
+            'package_items' => ['sometimes', 'array'],
+            'package_items.*.product_id' => ['required', 'integer', 'exists:products,id', 'distinct'],
+            'package_items.*.quantity' => ['required', 'integer', 'min:1'],
         ];
     }
 }

--- a/app/backend/app/Http/Requests/Api/V1/UpdateProductRequest.php
+++ b/app/backend/app/Http/Requests/Api/V1/UpdateProductRequest.php
@@ -7,6 +7,7 @@ namespace App\Http\Requests\Api\V1;
 use App\Models\Commerce;
 use App\Models\Product;
 use App\Services\ProductService;
+use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
@@ -101,5 +102,29 @@ class UpdateProductRequest extends FormRequest
             'package_items.*.product_id' => ['required', 'integer', 'exists:products,id', 'distinct'],
             'package_items.*.quantity' => ['required', 'integer', 'min:1'],
         ];
+    }
+
+    /**
+     * Configure the validator instance.
+     */
+    public function withValidator(Validator $validator): void
+    {
+        $validator->after(function ($validator) {
+            if ($this->has('package_items')) {
+                foreach ($this->input('package_items', []) as $index => $item) {
+                    if (isset($item['product_id']) && isset($item['quantity'])) {
+                        $product = Product::find($item['product_id']);
+                        if ($product) {
+                            if ($item['quantity'] > $product->quantity_available) {
+                                $validator->errors()->add(
+                                    "package_items.{$index}.quantity",
+                                    "The quantity cannot exceed the available quantity ({$product->quantity_available}) of product '{$product->title}'."
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        });
     }
 }

--- a/app/backend/app/Http/Resources/Api/V1/ProductResource.php
+++ b/app/backend/app/Http/Resources/Api/V1/ProductResource.php
@@ -23,6 +23,22 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *   @OA\Property(property="quantity_available", type="integer"),
  *   @OA\Property(property="expires_at", type="string", format="date-time", nullable=true),
  *   @OA\Property(property="photos", type="array", @OA\Items(ref="#/components/schemas/DocumentUploadResource")),
+ *   @OA\Property(
+ *     property="package_items",
+ *     type="array",
+ *     description="Products included in this package (only when loaded)",
+ *
+ *     @OA\Items(
+ *       type="object",
+ *
+ *       @OA\Property(property="id", type="integer"),
+ *       @OA\Property(property="title", type="string"),
+ *       @OA\Property(property="product_type", type="string"),
+ *       @OA\Property(property="original_price", type="number", format="float"),
+ *       @OA\Property(property="discounted_price", type="number", format="float", nullable=true),
+ *       @OA\Property(property="quantity", type="integer", description="Quantity of this product in the package")
+ *     )
+ *   ),
  *   @OA\Property(property="status", type="string"),
  *   @OA\Property(property="created_at", type="string", format="date-time"),
  *   @OA\Property(property="updated_at", type="string", format="date-time")
@@ -53,6 +69,18 @@ class ProductResource extends JsonResource
             'photos' => $this->whenLoaded('photos', function () {
                 return $this->photos->map(function ($photo) {
                     return new DocumentUploadResource($photo, ['product_id' => $this->id]);
+                });
+            }),
+            'package_items' => $this->whenLoaded('packageItems', function () {
+                return $this->packageItems->map(function ($item) {
+                    return [
+                        'id' => $item->id,
+                        'title' => $item->title,
+                        'product_type' => $item->product_type,
+                        'original_price' => $item->original_price,
+                        'discounted_price' => $item->discounted_price,
+                        'quantity' => $item->pivot->quantity,
+                    ];
                 });
             }),
             'status' => $this->status,

--- a/app/backend/app/Models/Product.php
+++ b/app/backend/app/Models/Product.php
@@ -130,7 +130,8 @@ class Product extends Model
      */
     public function packageItems()
     {
-        return $this->belongsToMany(Product::class, 'product_package_items', 'product_package_id', 'product_id');
+        return $this->belongsToMany(Product::class, 'product_package_items', 'product_package_id', 'product_id')
+            ->withPivot('quantity');
     }
 
     /**
@@ -140,7 +141,8 @@ class Product extends Model
      */
     public function package()
     {
-        return $this->belongsToMany(Product::class, 'product_package_items', 'product_id', 'product_package_id');
+        return $this->belongsToMany(Product::class, 'product_package_items', 'product_id', 'product_package_id')
+            ->withPivot('quantity');
     }
 
     /**

--- a/app/backend/app/Services/ProductService.php
+++ b/app/backend/app/Services/ProductService.php
@@ -253,7 +253,7 @@ class ProductService
         try {
             $product = Product::where(['id' => $product_package_id, 'product_type' => Constant::PRODUCT_TYPE_PACKAGE])->firstOrFail();
 
-            return $product;
+            return $product->load(['packageItems', 'packageItems.photos']);
         } catch (ModelNotFoundException $e) {
             Log::error('Error fetching package items for product ID: '.$product_package_id, ['error' => $e->getMessage()]);
             throw new ModelNotFoundException('Product Package not found with the specified ID.');
@@ -277,10 +277,13 @@ class ProductService
                 $productPackage->packageItems()->detach();
 
                 if (isset($data['package_items']) && is_array($data['package_items'])) {
-                    $productPackage->packageItems()->attach($data['package_items']);
+                    $itemsWithQuantity = collect($data['package_items'])->mapWithKeys(function ($item) {
+                        return [$item['product_id'] => ['quantity' => $item['quantity']]];
+                    })->toArray();
+                    $productPackage->packageItems()->attach($itemsWithQuantity);
                 }
 
-                return $productPackage;
+                return $productPackage->load(['packageItems', 'packageItems.photos']);
             });
 
         } catch (Exception $e) {
@@ -301,10 +304,13 @@ class ProductService
             $productPackage = $this->update($product_package_id, $items);
             $productPackage->packageItems()->detach();
             if (! empty($items['package_items'])) {
-                $productPackage->packageItems()->attach($items['package_items']);
+                $itemsWithQuantity = collect($items['package_items'])->mapWithKeys(function ($item) {
+                    return [$item['product_id'] => ['quantity' => $item['quantity']]];
+                })->toArray();
+                $productPackage->packageItems()->attach($itemsWithQuantity);
             }
 
-            return $productPackage;
+            return $productPackage->load(['packageItems', 'packageItems.photos']);
 
         } catch (Exception $e) {
             Log::error('Error updating ProductPackageItems', ['error' => $e->getMessage()]);

--- a/app/backend/database/migrations/2026_04_20_000000_add_quantity_to_product_package_items_table.php
+++ b/app/backend/database/migrations/2026_04_20_000000_add_quantity_to_product_package_items_table.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('product_package_items', function (Blueprint $table) {
+            $table->unsignedInteger('quantity')->default(1)->after('product_package_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('product_package_items', function (Blueprint $table) {
+            $table->dropColumn('quantity');
+        });
+    }
+};

--- a/app/backend/tests/Feature/Api/V1/ProductFeatureTest.php
+++ b/app/backend/tests/Feature/Api/V1/ProductFeatureTest.php
@@ -391,7 +391,11 @@ class ProductFeatureTest extends TestCase
             'commerce_id' => $commerce->id,
             'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
         ]);
-        $product = Product::factory()->create(['commerce_id' => $package->commerce_id]);
+        $product = Product::factory()->create([
+            'commerce_id' => $package->commerce_id,
+            'quantity_total' => 10,
+            'quantity_available' => 10,
+        ]);
 
         $package->packageItems()->attach($product->id, ['quantity' => 2]);
 
@@ -439,5 +443,72 @@ class ProductFeatureTest extends TestCase
         $response = $this->postJson('/api/v1/products/commerce/package-items', $payload);
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['package_items.1.product_id']);
+    }
+
+    public function test_store_package_items_rejects_quantity_exceeding_available()
+    {
+        $user = $this->actingAsAdmin();
+        $commerce = Commerce::factory()->create(['owner_user_id' => $user->id]);
+        $commerceBranch = CommerceBranch::factory()->create(['commerce_id' => $commerce->id]);
+        $category = ProductCategory::factory()->create();
+        // Producto con solo 5 unidades disponibles
+        $product = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'quantity_total' => 10,
+            'quantity_available' => 5,
+        ]);
+
+        $payload = [
+            'product' => [
+                'commerce_id' => $commerce->id,
+                'product_category_id' => $category->id,
+                'title' => 'Test Package',
+                'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+                'original_price' => 100,
+                'quantity_total' => 10,
+                'quantity_available' => 10,
+            ],
+            'package_items' => [
+                ['product_id' => $product->id, 'quantity' => 10], // Excede las 5 disponibles
+            ],
+            'commerce_branch_ids' => [$commerceBranch->id],
+        ];
+
+        $response = $this->postJson('/api/v1/products/commerce/package-items', $payload);
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['package_items.0.quantity']);
+    }
+
+    public function test_update_package_items_rejects_quantity_exceeding_available()
+    {
+        $user = $this->actingAsAdmin();
+        $commerce = Commerce::factory()->create(['owner_user_id' => $user->id]);
+        $commerceBranch = CommerceBranch::factory()->create(['commerce_id' => $commerce->id]);
+        $package = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+        ]);
+        // Producto con solo 3 unidades disponibles
+        $product = Product::factory()->create([
+            'commerce_id' => $package->commerce_id,
+            'quantity_total' => 10,
+            'quantity_available' => 3,
+        ]);
+
+        $package->packageItems()->attach($product->id, ['quantity' => 2]);
+
+        $payload = [
+            'product' => [
+                'commerce_id' => $package->commerce_id,
+            ],
+            'package_items' => [
+                ['product_id' => $product->id, 'quantity' => 7], // Excede las 3 disponibles
+            ],
+            'commerce_branch_ids' => [$commerceBranch->id],
+        ];
+
+        $response = $this->putJson('/api/v1/products/commerce/package-items/'.$package->id, $payload);
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['package_items.0.quantity']);
     }
 }

--- a/app/backend/tests/Feature/Api/V1/ProductFeatureTest.php
+++ b/app/backend/tests/Feature/Api/V1/ProductFeatureTest.php
@@ -181,7 +181,10 @@ class ProductFeatureTest extends TestCase
         $package = Product::factory()->create(['product_type' => Constant::PRODUCT_TYPE_PACKAGE]);
         $item1 = Product::factory()->create(['commerce_id' => $package->commerce_id]);
         $item2 = Product::factory()->create(['commerce_id' => $package->commerce_id]);
-        $package->packageItems()->attach([$item1->id, $item2->id]);
+        $package->packageItems()->attach([
+            $item1->id => ['quantity' => 1],
+            $item2->id => ['quantity' => 1],
+        ]);
         $payload = ['id' => $package->id];
         $response = $this->deleteJson('/api/v1/products/commerce/package-items/'.$package->id, $payload);
         $response->assertNoContent();
@@ -260,7 +263,10 @@ class ProductFeatureTest extends TestCase
         // Simular items de paquete
         $item1 = Product::factory()->create(['commerce_id' => $package->commerce_id]);
         $item2 = Product::factory()->create(['commerce_id' => $package->commerce_id]);
-        $package->packageItems()->attach([$item1->id, $item2->id]);
+        $package->packageItems()->attach([
+            $item1->id => ['quantity' => 2],
+            $item2->id => ['quantity' => 1],
+        ]);
 
         $response = $this->getJson('/api/v1/products/commerce/package-items/'.$package->id);
         $response->assertOk()
@@ -287,5 +293,151 @@ class ProductFeatureTest extends TestCase
                 'status' => false,
                 'message' => 'Product not found with the specified ID.',
             ]);
+    }
+
+    public function test_store_package_items_requires_quantity()
+    {
+        $user = $this->actingAsAdmin();
+        $commerce = Commerce::factory()->create(['owner_user_id' => $user->id]);
+        $commerceBranch = CommerceBranch::factory()->create(['commerce_id' => $commerce->id]);
+        $category = ProductCategory::factory()->create();
+        $product = Product::factory()->create(['commerce_id' => $commerce->id]);
+
+        $payload = [
+            'product' => [
+                'commerce_id' => $commerce->id,
+                'product_category_id' => $category->id,
+                'title' => 'Test Package',
+                'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+                'original_price' => 100,
+                'quantity_total' => 10,
+                'quantity_available' => 10,
+            ],
+            'package_items' => [
+                ['product_id' => $product->id], // Missing quantity
+            ],
+            'commerce_branch_ids' => [$commerceBranch->id],
+        ];
+
+        $response = $this->postJson('/api/v1/products/commerce/package-items', $payload);
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['package_items.0.quantity']);
+    }
+
+    public function test_store_package_items_rejects_zero_quantity()
+    {
+        $user = $this->actingAsAdmin();
+        $commerce = Commerce::factory()->create(['owner_user_id' => $user->id]);
+        $commerceBranch = CommerceBranch::factory()->create(['commerce_id' => $commerce->id]);
+        $category = ProductCategory::factory()->create();
+        $product = Product::factory()->create(['commerce_id' => $commerce->id]);
+
+        $payload = [
+            'product' => [
+                'commerce_id' => $commerce->id,
+                'product_category_id' => $category->id,
+                'title' => 'Test Package',
+                'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+                'original_price' => 100,
+                'quantity_total' => 10,
+                'quantity_available' => 10,
+            ],
+            'package_items' => [
+                ['product_id' => $product->id, 'quantity' => 0],
+            ],
+            'commerce_branch_ids' => [$commerceBranch->id],
+        ];
+
+        $response = $this->postJson('/api/v1/products/commerce/package-items', $payload);
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['package_items.0.quantity']);
+    }
+
+    public function test_store_package_items_rejects_negative_quantity()
+    {
+        $user = $this->actingAsAdmin();
+        $commerce = Commerce::factory()->create(['owner_user_id' => $user->id]);
+        $commerceBranch = CommerceBranch::factory()->create(['commerce_id' => $commerce->id]);
+        $category = ProductCategory::factory()->create();
+        $product = Product::factory()->create(['commerce_id' => $commerce->id]);
+
+        $payload = [
+            'product' => [
+                'commerce_id' => $commerce->id,
+                'product_category_id' => $category->id,
+                'title' => 'Test Package',
+                'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+                'original_price' => 100,
+                'quantity_total' => 10,
+                'quantity_available' => 10,
+            ],
+            'package_items' => [
+                ['product_id' => $product->id, 'quantity' => -5],
+            ],
+            'commerce_branch_ids' => [$commerceBranch->id],
+        ];
+
+        $response = $this->postJson('/api/v1/products/commerce/package-items', $payload);
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['package_items.0.quantity']);
+    }
+
+    public function test_update_package_items_updates_quantity()
+    {
+        $user = $this->actingAsAdmin();
+        $commerce = Commerce::factory()->create(['owner_user_id' => $user->id]);
+        $commerceBranch = CommerceBranch::factory()->create(['commerce_id' => $commerce->id]);
+        $package = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+        ]);
+        $product = Product::factory()->create(['commerce_id' => $package->commerce_id]);
+
+        $package->packageItems()->attach($product->id, ['quantity' => 2]);
+
+        $payload = [
+            'product' => [
+                'commerce_id' => $package->commerce_id,
+            ],
+            'package_items' => [
+                ['product_id' => $product->id, 'quantity' => 5],
+            ],
+            'commerce_branch_ids' => [$commerceBranch->id],
+        ];
+
+        $response = $this->putJson('/api/v1/products/commerce/package-items/'.$package->id, $payload);
+        $response->assertOk();
+
+        $this->assertEquals(5, $package->fresh()->packageItems()->first()->pivot->quantity);
+    }
+
+    public function test_store_package_items_prevents_duplicate_products()
+    {
+        $user = $this->actingAsAdmin();
+        $commerce = Commerce::factory()->create(['owner_user_id' => $user->id]);
+        $commerceBranch = CommerceBranch::factory()->create(['commerce_id' => $commerce->id]);
+        $category = ProductCategory::factory()->create();
+        $product = Product::factory()->create(['commerce_id' => $commerce->id]);
+
+        $payload = [
+            'product' => [
+                'commerce_id' => $commerce->id,
+                'product_category_id' => $category->id,
+                'title' => 'Test Package',
+                'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+                'original_price' => 100,
+                'quantity_total' => 10,
+                'quantity_available' => 10,
+            ],
+            'package_items' => [
+                ['product_id' => $product->id, 'quantity' => 2],
+                ['product_id' => $product->id, 'quantity' => 3], // Duplicate
+            ],
+            'commerce_branch_ids' => [$commerceBranch->id],
+        ];
+
+        $response = $this->postJson('/api/v1/products/commerce/package-items', $payload);
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['package_items.1.product_id']);
     }
 }


### PR DESCRIPTION
This pull request implements a breaking change to support quantities for products within a package. The main update is the addition of a `quantity` field in the `product_package_items` pivot table, requiring API consumers to send and receive package items as objects containing both `product_id` and `quantity`. The change spans database migration, model relationships, validation, business logic, API resource responses, and tests.

**Database and Model Updates**
- Added a migration to include a `quantity` (unsigned integer, default 1) column to the `product_package_items` table. Updated `Product` model relationships (`packageItems`, `package`) to use `withPivot('quantity')`. 

**API Validation and Contracts**
- Updated `StoreProductRequest` and `UpdateProductRequest` to validate `package_items` as arrays of objects with `product_id` and `quantity`, ensuring `quantity` is required, integer, min 1, distinct per `product_id`, and does not exceed the product’s available quantity. Also updated Swagger documentation to reflect the new structure.

**Business Logic Adjustments**
- Modified `ProductService` methods (`storePackageItems`, `updatePackageItems`, `getProductPackage`) to handle the new structure, attaching items with quantities and loading related data. 
**API Response Changes**
- Updated `ProductResource` to include `quantity` for each item in the `package_items` array in API responses, with corresponding Swagger documentation updates.

**Test Suite Updates**
- Refactored and extended tests to cover the new structure, validation rules, and edge cases (e.g., zero/negative quantity, exceeding available quantity, duplicate products). 

**Breaking Change Notice**
- The request/response format for package items has changed from an array of IDs to an array of objects with `product_id` and `quantity`. All API consumers must update their integration accordingly.

For more details, see the included implementation plan in `.opencode/plans/productPackageItemsQuantity.prompt.md`.