### PR TITLE
feat(frontend): completar onboarding provider/app, reforzar auth y habilitar duplicación MVP de productos

### DIFF
--- a/app/frontend/src/components/app/auth/app-register-form.tsx
+++ b/app/frontend/src/components/app/auth/app-register-form.tsx
@@ -5,10 +5,12 @@ import { useRouter } from "next/navigation";
 import { Eye, EyeOff, Mail, User } from "lucide-react";
 
 import { useAppAuthForm } from "@/hooks/app/use-app-auth-form";
+import { PASSWORD_MIN_LENGTH, validatePasswordPolicy } from "@/lib/auth/password-policy";
 import { Button } from "@/components/app/ui/button";
 import { Input } from "@/components/app/ui/input";
 
 const PASSWORD_MISMATCH_ERROR = "Las contrasenas no coinciden. Verifica ambos campos.";
+const PASSWORD_POLICY_ERROR = "La contraseña aun no cumple todos los criterios de seguridad.";
 
 export default function AppRegisterForm() {
   const [name, setName] = useState("");
@@ -18,17 +20,21 @@ export default function AppRegisterForm() {
   const [showPassword, setShowPassword] = useState(false);
   const { handleRegister, loading, error, clearError } = useAppAuthForm();
   const router = useRouter();
+  const passwordPolicy = validatePasswordPolicy(password);
+  const hasWeakPassword = password.length > 0 && !passwordPolicy.isStrong;
   const hasPasswordMismatch =
     confirmPassword.length > 0 && password !== confirmPassword;
   const resolvedErrorMessage = hasPasswordMismatch
     ? PASSWORD_MISMATCH_ERROR
-    : error;
+    : hasWeakPassword
+      ? PASSWORD_POLICY_ERROR
+      : error;
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     clearError();
 
-    if (hasPasswordMismatch) {
+    if (hasPasswordMismatch || hasWeakPassword) {
       return;
     }
 
@@ -86,11 +92,40 @@ export default function AppRegisterForm() {
             placeholder="Contraseña"
             value={password}
             onChange={(event) => setPassword(event.target.value)}
-            className="h-12 rounded-xl border-[#E6E6E6] bg-white pl-10 focus:border-[#5A1E6B] focus:ring-[#5A1E6B]"
+            className={`h-12 rounded-xl bg-white pl-10 focus:ring-[#5A1E6B] ${
+              hasWeakPassword
+                ? "border-[#B9342D] focus:border-[#B9342D]"
+                : "border-[#E6E6E6] focus:border-[#5A1E6B]"
+            }`}
             aria-label="Contraseña"
+            aria-invalid={hasWeakPassword}
             autoComplete="new-password"
             required
           />
+        </div>
+
+        <div className="rounded-xl border border-[#EADCF1] bg-[#FCF8FE] px-4 py-3">
+          <p className="mb-2 text-xs font-semibold text-[#5A1E6B]">Criterios de seguridad</p>
+          <div className="grid grid-cols-1 gap-1 text-xs sm:grid-cols-2">
+            <p className={passwordPolicy.minLength ? "text-[#2F6F3E]" : "text-[#7A2E9A]"}>
+              {passwordPolicy.minLength ? "OK" : "-"} Minimo {PASSWORD_MIN_LENGTH} caracteres
+            </p>
+            <p className={passwordPolicy.hasUppercase ? "text-[#2F6F3E]" : "text-[#7A2E9A]"}>
+              {passwordPolicy.hasUppercase ? "OK" : "-"} Una mayuscula
+            </p>
+            <p className={passwordPolicy.hasLowercase ? "text-[#2F6F3E]" : "text-[#7A2E9A]"}>
+              {passwordPolicy.hasLowercase ? "OK" : "-"} Una minuscula
+            </p>
+            <p className={passwordPolicy.hasNumber ? "text-[#2F6F3E]" : "text-[#7A2E9A]"}>
+              {passwordPolicy.hasNumber ? "OK" : "-"} Un numero
+            </p>
+            <p className={passwordPolicy.hasSymbol ? "text-[#2F6F3E]" : "text-[#7A2E9A]"}>
+              {passwordPolicy.hasSymbol ? "OK" : "-"} Un simbolo
+            </p>
+            <p className={passwordPolicy.noSpaces ? "text-[#2F6F3E]" : "text-[#7A2E9A]"}>
+              {passwordPolicy.noSpaces ? "OK" : "-"} Sin espacios
+            </p>
+          </div>
         </div>
 
         <div className="relative">
@@ -129,7 +164,7 @@ export default function AppRegisterForm() {
         <Button
           type="submit"
           className="h-12 w-full rounded-xl bg-[#5A1E6B] text-white hover:bg-[#7A2E9A]"
-          disabled={loading}
+          disabled={loading || hasWeakPassword || hasPasswordMismatch}
           aria-busy={loading}
         >
           {loading ? "Creando cuenta..." : "Crear cuenta"}

--- a/app/frontend/src/lib/api/app-auth.ts
+++ b/app/frontend/src/lib/api/app-auth.ts
@@ -42,6 +42,31 @@ function ensureRequiredFields(fields: Array<string>, message: string): void {
   }
 }
 
+function splitNameParts(fullName: string, explicitLastName?: string): { name: string; last_name: string } {
+  const normalizedName = fullName.trim().replace(/\s+/g, " ");
+  const normalizedLastName = (explicitLastName ?? "").trim().replace(/\s+/g, " ");
+
+  if (normalizedLastName.length > 0) {
+    return {
+      name: normalizedName,
+      last_name: normalizedLastName,
+    };
+  }
+
+  const parts = normalizedName.split(" ");
+  if (parts.length >= 2) {
+    return {
+      name: parts[0],
+      last_name: parts.slice(1).join(" "),
+    };
+  }
+
+  return {
+    name: normalizedName,
+    last_name: "Usuario",
+  };
+}
+
 function mapResponseToSession(data: LoginResponse): { user: SessionData; redirectTo: string } {
   const apiUser = data.data;
   const userRole = apiUser.roles && apiUser.roles.length > 0 ? apiUser.roles[0] : "user";
@@ -109,7 +134,7 @@ export async function loginAppUser({ email, password }: AppLoginPayload): Promis
 
 /**
  * Dedicated register for app/customer surface.
- * Expected backend endpoint: POST /api/v1/app/register (or customer/register).
+ * Backend endpoint: POST /api/v1/customer/register.
  */
 export async function registerAppUser({
   name,
@@ -123,15 +148,17 @@ export async function registerAppUser({
     "Por favor completa todos los campos."
   );
 
-  const response = await fetch(`${API_URL}/api/v1/app/register`, {
+  const normalizedNameParts = splitNameParts(name, last_name);
+
+  const response = await fetch(`${API_URL}/api/v1/customer/register`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       Accept: "application/json",
     },
     body: JSON.stringify({
-      name,
-      last_name: (last_name || "").trim() || "app",
+      name: normalizedNameParts.name,
+      last_name: normalizedNameParts.last_name,
       email,
       password,
       password_confirmation,


### PR DESCRIPTION
## Resumen
Este PR agrupa mejoras frontend en onboarding, autenticación y gestión de productos.

Incluye:
1. Refactor y mejoras del módulo de productos de provider, incluyendo duplicación MVP mediante modal de creación precargado.
2. Reforzamiento de política de contraseñas y reutilización de la validación compartida entre módulos.
3. Alineación del registro del módulo app con el endpoint real de backend para customer.
4. Calidad:
   Fix de lint para React Hooks en el formulario de productos, validado contra CI.

## Notas de alcance
1. La duplicación de productos es MVP frontend-driven. Abre modal precargado, pero no implementa aún un endpoint backend dedicado para clonado 1:1.
2. El bloque `discover -> product -> cart` del módulo app sigue marcado como WIP y no cierra todavía todo el flujo.
3. La validación fuerte de contraseña está consolidada en frontend; el backend mantiene sus reglas actuales.

## Checklist de validación
1. Registro provider rechaza contraseñas débiles y muestra criterios de seguridad.
2. Registro app crea customer usando el endpoint correcto y redirige al dashboard.
3. Duplicar producto abre modal con datos precargados.
4. Lint frontend pasa correctamente.