### PR TITLE
feat(products): incluir elementos de paquete en las respuestas de producto

### DIFF
--- a/app/backend/app/Http/Controllers/Api/V1/ProductController.php
+++ b/app/backend/app/Http/Controllers/Api/V1/ProductController.php
@@ -15,7 +15,6 @@ use App\Http\Requests\Api\V1\StoreProductRequest;
 use App\Http\Requests\Api\V1\UpdateProductRequest;
 use App\Http\Resources\Api\V1\DocumentUploadResource;
 use App\Http\Resources\Api\V1\ProductResource;
-use App\Http\Resources\Api\V1\ProductResourceCollection;
 use App\Models\ProductPhoto;
 use App\Services\CommerceService;
 use App\Services\DocumentUploadService;
@@ -399,9 +398,8 @@ class ProductController extends Controller
     {
         try {
             $product = $this->productService->getProductPackage($product_package_id);
-            $items = $product->packageItems;
 
-            return $this->successResponse(new ProductResourceCollection($items), 'Package items fetched successfully', 200);
+            return $this->successResponse(new ProductResource($product), 'Package items fetched successfully', 200);
         } catch (ModelNotFoundException $e) {
             return $this->errorResponse('Product not found with the specified ID.', 404);
         } catch (Exception $e) {

--- a/app/backend/app/Services/ProductService.php
+++ b/app/backend/app/Services/ProductService.php
@@ -221,7 +221,9 @@ class ProductService
     public function getByCommerce(int $commerce_id)
     {
         try {
-            return Product::with('photos')->where('commerce_id', $commerce_id)->get();
+            return Product::with(['photos', 'packageItems', 'packageItems.photos'])
+                ->where('commerce_id', $commerce_id)
+                ->get();
         } catch (ModelNotFoundException $e) {
             Log::error('Error fetching products by commerce ID', ['error' => $e->getMessage()]);
             throw $e;
@@ -235,9 +237,10 @@ class ProductService
      */
     public function getByCommerceBranch(int $branch_id)
     {
-        $products = Product::with('photos')->whereHas('commerce.commerceBranches', function ($query) use ($branch_id) {
-            $query->where('id', $branch_id);
-        })->get();
+        $products = Product::with(['photos', 'packageItems', 'packageItems.photos'])
+            ->whereHas('commerce.commerceBranches', function ($query) use ($branch_id) {
+                $query->where('id', $branch_id);
+            })->get();
 
         if ($products->isEmpty()) {
             throw new ModelNotFoundException('No products found for the given commerce branch.');

--- a/app/backend/tests/Feature/Api/V1/ProductFeatureTest.php
+++ b/app/backend/tests/Feature/Api/V1/ProductFeatureTest.php
@@ -233,6 +233,51 @@ class ProductFeatureTest extends TestCase
             ]);
     }
 
+    public function test_get_products_by_commerce_includes_package_items_when_loaded()
+    {
+        $this->actingAsAdmin();
+        $commerce = Commerce::factory()->create();
+        $package = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+        ]);
+        $item = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'product_type' => Constant::PRODUCT_TYPE_SINGLE,
+        ]);
+        $package->packageItems()->attach([
+            $item->id => ['quantity' => 2],
+        ]);
+
+        $response = $this->getJson('/api/v1/products/commerce/'.$commerce->id);
+        $response->assertOk()
+            ->assertJsonPath('data.0.package_items.0.id', $item->id)
+            ->assertJsonPath('data.0.package_items.0.quantity', 2);
+    }
+
+    public function test_get_products_by_commerce_branch_includes_package_items_when_loaded()
+    {
+        $this->actingAsAdmin();
+        $commerce = Commerce::factory()->create();
+        $branch = CommerceBranch::factory()->create(['commerce_id' => $commerce->id]);
+        $package = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+        ]);
+        $item = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'product_type' => Constant::PRODUCT_TYPE_SINGLE,
+        ]);
+        $package->packageItems()->attach([
+            $item->id => ['quantity' => 1],
+        ]);
+
+        $response = $this->getJson('/api/v1/products/commerce/branch/'.$branch->id);
+        $response->assertOk()
+            ->assertJsonPath('data.0.package_items.0.id', $item->id)
+            ->assertJsonPath('data.0.package_items.0.quantity', 1);
+    }
+
     public function test_get_products_by_commerce_branch_returns_404_when_none_found()
     {
         $this->actingAsAdmin();
@@ -270,8 +315,8 @@ class ProductFeatureTest extends TestCase
 
         $response = $this->getJson('/api/v1/products/commerce/package-items/'.$package->id);
         $response->assertOk()
-            ->assertJsonStructure(['data'])
-            ->assertJsonCount(2, 'data');
+            ->assertJsonStructure(['data' => ['package_items']])
+            ->assertJsonCount(2, 'data.package_items');
     }
 
     public function test_get_package_items_returns_empty_when_none()
@@ -280,7 +325,7 @@ class ProductFeatureTest extends TestCase
         $package = Product::factory()->create(['product_type' => Constant::PRODUCT_TYPE_PACKAGE]);
         $response = $this->getJson('/api/v1/products/commerce/package-items/'.$package->id);
         $response->assertOk()
-            ->assertJson(['data' => []]);
+            ->assertJson(['data' => ['package_items' => []]]);
     }
 
     public function test_get_package_items_returns_404_for_invalid_product()


### PR DESCRIPTION
This pull request updates how product package items are loaded and returned in the API, ensuring that related package items (and their photos) are consistently included in product queries and responses. It also updates the related tests to reflect these changes and adds new tests to ensure package items are present in API responses.

**API Response Changes:**

* The `getPackageItems` endpoint now returns a single `ProductResource` (with its `package_items` relation) instead of a collection of items, ensuring a more consistent and informative response structure.
* The `ProductService` methods `getByCommerce` and `getByCommerceBranch` now eagerly load `packageItems` and their `photos` along with the main product and its photos, ensuring all related data is available in API responses. 
* 
**Testing Improvements:**

* New tests verify that the products returned by the commerce and branch endpoints include their `package_items` with correct IDs and quantities.
* Existing tests for package item endpoints have been updated to check for the new nested `package_items` structure in the JSON response, both when items are present and when the list is empty.