### PR TITLE
feat(frontend): flujo de recuperación de contraseña y ajustes de datos de proveedor

### DIFF
--- a/app/frontend/src/app/reset-password/page.tsx
+++ b/app/frontend/src/app/reset-password/page.tsx
@@ -1,0 +1,41 @@
+import { AuthBranding } from "@/components/provider/auth/auth-branding";
+import { ResetPasswordForm } from "@/components/provider/auth/reset-password-form";
+
+export const metadata = {
+  title: "Restablecer Contraseña | Sumass",
+  description: "Restablece tu contraseña usando el token de recuperación recibido por correo",
+};
+
+interface ResetPasswordPageProps {
+  searchParams?: {
+    email?: string | string[];
+    token?: string | string[];
+  };
+}
+
+function getSingleQueryParam(param?: string | string[]): string {
+  if (typeof param === "string") return param;
+  if (Array.isArray(param) && param.length > 0) return param[0] || "";
+  return "";
+}
+
+export default function ResetPasswordPage({ searchParams }: ResetPasswordPageProps) {
+  const initialEmail = getSingleQueryParam(searchParams?.email);
+  const initialToken = getSingleQueryParam(searchParams?.token);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-[#DDE8BB]/30 via-white to-[#DDE8BB]/10 flex items-center justify-center p-4">
+      <div className="w-full max-w-6xl">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-12">
+          <AuthBranding />
+
+          <div className="flex items-center justify-center">
+            <div className="w-full max-w-md bg-white rounded-[18px] shadow-lg border-0 p-8">
+              <ResetPasswordForm initialEmail={initialEmail} initialToken={initialToken} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/frontend/src/components/admin/shared/provider-details-tabs/provider-datos-basicos-tab.tsx
+++ b/app/frontend/src/components/admin/shared/provider-details-tabs/provider-datos-basicos-tab.tsx
@@ -60,7 +60,7 @@ export function ProviderDatosBasicosTab({
           )}
         </div>
 
-        {/* NIT */}
+        {/* Documento del Proveedor */}
         <div>
           <label className="block text-sm font-medium text-[#1A1A1A] mb-2">
             {formData.tipoDocumento} <span className="text-red-500">*</span>
@@ -98,20 +98,20 @@ export function ProviderDatosBasicosTab({
         {/*Tipo de documento y documento del representante legal*/}
         <div>
           <label className="block text-sm font-medium text-[#1A1A1A] mb-2">
-            {formData.tipoDocumento} del Representante Legal
+            {formData.tipoDocumentoRepresentante} del Representante Legal
           </label>
           <input
             type="text"
-            value={formData.nit || ''}
-            onChange={(e) => onFieldChange('nit', e.target.value)}
+            value={formData.documentoRepresentante || ''}
+            onChange={(e) => onFieldChange('documentoRepresentante', e.target.value)}
             disabled={isViewMode}
             className={`w-full h-[50px] px-4 border rounded-[14px] focus:outline-none focus:ring-2 focus:ring-[#4B236A] disabled:bg-[#F7F7F7] disabled:text-[#6A6A6A] transition-colors ${
-              errors.nit ? 'border-red-500' : 'border-[#E0E0E0]'
+              errors.documentoRepresentante ? 'border-red-500' : 'border-[#E0E0E0]'
             }`}
             placeholder="Ej: 900123456-7"
           />
-          {errors.nit && (
-            <p className="mt-1 text-sm text-red-500">{errors.nit}</p>
+          {errors.documentoRepresentante && (
+            <p className="mt-1 text-sm text-red-500">{errors.documentoRepresentante}</p>
           )}
         </div>
 

--- a/app/frontend/src/components/provider/auth/forgot-password-form.tsx
+++ b/app/frontend/src/components/provider/auth/forgot-password-form.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+import Link from "next/link";
+import { ArrowLeft, Mail } from "lucide-react";
+import { requestPasswordReset } from "@/lib/api/auth";
+import { Button } from "@/components/provider/ui/button";
+import { Input } from "@/components/provider/ui/input";
+import { Label } from "@/components/provider/ui/label";
+import { cn } from "@/components/provider/ui/utils";
+
+interface ForgotPasswordFormProps {
+  onBackToLogin?: () => void;
+}
+
+export function ForgotPasswordForm({ onBackToLogin }: ForgotPasswordFormProps) {
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState(
+    "Si el correo está registrado, recibirás instrucciones para restablecer tu contraseña."
+  );
+  const [success, setSuccess] = useState(false);
+
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const normalizedEmail = email.trim().toLowerCase();
+
+    if (!normalizedEmail) {
+      setError("Por favor ingresa tu correo electrónico");
+      return;
+    }
+
+    if (!emailRegex.test(normalizedEmail)) {
+      setError("Por favor ingresa un correo válido");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const result = await requestPasswordReset({ email: normalizedEmail });
+      setSuccessMessage(
+        result.message ||
+          "Si el correo está registrado, recibirás instrucciones para restablecer tu contraseña."
+      );
+      setSuccess(true);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "No se pudo procesar la solicitud.";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <h2 className="text-2xl font-bold tracking-tight text-[#1A1A1A]">Recuperar contraseña</h2>
+        <p className="text-sm text-[#6A6A6A]">
+          Ingresa tu correo y te enviaremos instrucciones para restablecer tu contraseña.
+        </p>
+      </div>
+
+      {success ? (
+        <div className="space-y-4">
+          <div className="rounded-[12px] border border-emerald-200 bg-emerald-50 p-3">
+            <p className="text-sm text-emerald-700">{successMessage}</p>
+          </div>
+
+          <Link
+            href={`/reset-password?email=${encodeURIComponent(email.trim().toLowerCase())}`}
+            className="block w-full"
+          >
+            <Button
+              type="button"
+              className={cn(
+                "w-full h-[52px] rounded-[14px] font-medium",
+                "bg-[#DDE8BB] text-[#1A1A1A] hover:bg-[#C8D86D]",
+                "transition-all duration-200"
+              )}
+            >
+              Ya tengo token de recuperación
+            </Button>
+          </Link>
+
+          <Button
+            type="button"
+            onClick={onBackToLogin}
+            className={cn(
+              "w-full h-[52px] rounded-[14px] text-white font-medium",
+              "bg-[#4B236A] hover:bg-[#5D2B7D]",
+              "transition-all duration-200 shadow-lg hover:shadow-xl"
+            )}
+          >
+            Volver a iniciar sesión
+          </Button>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="forgot-email" className="text-[#1A1A1A] font-semibold">
+              Correo Electrónico
+            </Label>
+            <div className="relative">
+              <Mail className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-gray-400" />
+              <Input
+                id="forgot-email"
+                type="email"
+                value={email}
+                placeholder="correo@ejemplo.com"
+                onChange={(e) => setEmail(e.target.value)}
+                disabled={loading}
+                className={cn(
+                  "pl-10 h-[50px] rounded-[14px] border-[#E0E0E0] placeholder-gray-400",
+                  "focus:border-[#4B236A] focus:ring-2 focus:ring-[#4B236A]/20"
+                )}
+              />
+            </div>
+          </div>
+
+          {error && (
+            <div className="rounded-[12px] bg-red-50 border border-red-200 p-3">
+              <p className="text-sm text-red-700">{error}</p>
+            </div>
+          )}
+
+          <Button
+            type="submit"
+            disabled={loading}
+            className={cn(
+              "w-full h-[52px] rounded-[14px] text-white font-medium",
+              "bg-[#4B236A] hover:bg-[#5D2B7D]",
+              "disabled:opacity-50 disabled:cursor-not-allowed",
+              "transition-all duration-200 shadow-lg hover:shadow-xl"
+            )}
+          >
+            {loading ? "Enviando solicitud..." : "Enviar instrucciones"}
+          </Button>
+
+          <button
+            type="button"
+            onClick={onBackToLogin}
+            className="mx-auto flex items-center gap-2 text-sm font-medium text-[#4B236A] hover:underline"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            Volver a iniciar sesión
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/app/frontend/src/components/provider/auth/login-form.tsx
+++ b/app/frontend/src/components/provider/auth/login-form.tsx
@@ -9,7 +9,11 @@ import { Input } from "@/components/provider/ui/input";
 import { Label } from "@/components/provider/ui/label";
 import { cn } from "@/components/provider/ui/utils";
 
-export function LoginForm() {
+interface LoginFormProps {
+  onForgotPassword?: () => void;
+}
+
+export function LoginForm({ onForgotPassword }: LoginFormProps) {
   const router = useRouter();
   const { handleLogin, loading, error, clearError } = useAuthForm();
   
@@ -118,9 +122,13 @@ export function LoginForm() {
 
       {/* Forgot password link */}
       <p className="text-center text-sm text-[#6A6A6A]">
-        <a href="#" className="font-medium text-[#4B236A] hover:underline">
+        <button
+          type="button"
+          onClick={onForgotPassword}
+          className="font-medium text-[#4B236A] hover:underline"
+        >
           ¿Olvidaste tu contraseña?
-        </a>
+        </button>
       </p>
     </form>
   );

--- a/app/frontend/src/components/provider/auth/provider-auth-page.tsx
+++ b/app/frontend/src/components/provider/auth/provider-auth-page.tsx
@@ -1,13 +1,19 @@
+"use client";
+
+import { useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/provider/ui/tabs";
 import { LoginForm } from "./login-form";
 import { RegisterForm } from "./register-form";
 import { AuthBranding } from "./auth-branding";
+import { ForgotPasswordForm } from "@/components/provider/auth/forgot-password-form";
 
 interface ProviderAuthPageProps {
-  defaultTab?: "login" | "register";
+  defaultTab?: "login" | "register" | "forgot-password";
 }
 
 export function ProviderAuthPage({ defaultTab = "login" }: ProviderAuthPageProps) {
+  const [activeTab, setActiveTab] = useState<"login" | "register" | "forgot-password">(defaultTab);
+
   return (
     <div className="min-h-screen bg-gradient-to-br from-[#DDE8BB]/30 via-white to-[#DDE8BB]/10 flex items-center justify-center p-4">
       <div className="w-full max-w-6xl">
@@ -18,7 +24,7 @@ export function ProviderAuthPage({ defaultTab = "login" }: ProviderAuthPageProps
           {/* Formularios */}
           <div className="flex items-center justify-center">
             <div className="w-full max-w-md bg-white rounded-[18px] shadow-lg border-0 p-8">
-              <Tabs defaultValue={defaultTab} className="w-full">
+              <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as "login" | "register" | "forgot-password")} className="w-full">
                 <TabsList className="grid w-full grid-cols-2 bg-[#DDE8BB]/20 rounded-[14px] p-1">
                   <TabsTrigger
                     value="login"
@@ -36,12 +42,17 @@ export function ProviderAuthPage({ defaultTab = "login" }: ProviderAuthPageProps
 
                 {/* Tab Login */}
                 <TabsContent value="login" className="mt-8">
-                  <LoginForm />
+                  <LoginForm onForgotPassword={() => setActiveTab("forgot-password")} />
                 </TabsContent>
 
                 {/* Tab Registro */}
                 <TabsContent value="register" className="mt-8">
-                  <RegisterForm />
+                  <RegisterForm onSwitchToLogin={() => setActiveTab("login")} />
+                </TabsContent>
+
+                {/* Recover Password Panel */}
+                <TabsContent value="forgot-password" className="mt-8">
+                  <ForgotPasswordForm onBackToLogin={() => setActiveTab("login")} />
                 </TabsContent>
               </Tabs>
             </div>

--- a/app/frontend/src/components/provider/auth/register-form.tsx
+++ b/app/frontend/src/components/provider/auth/register-form.tsx
@@ -12,9 +12,10 @@ import { cn } from "@/components/provider/ui/utils";
 
 interface RegisterFormProps {
   onSuccess?: () => void;
+  onSwitchToLogin?: () => void;
 }
 
-export function RegisterForm({ onSuccess }: RegisterFormProps) {
+export function RegisterForm({ onSuccess, onSwitchToLogin }: RegisterFormProps) {
   const router = useRouter();
   const { handleRegister, loading, error, clearError } = useAuthForm();
   const [showPassword, setShowPassword] = useState(false);
@@ -281,9 +282,13 @@ export function RegisterForm({ onSuccess }: RegisterFormProps) {
       {/* Link Login */}
       <p className="text-center text-sm text-[#6A6A6A]">
         ¿Ya tienes cuenta?{" "}
-        <a href="#" className="font-medium text-[#4B236A] hover:underline">
+        <button
+          type="button"
+          onClick={onSwitchToLogin}
+          className="font-medium text-[#4B236A] hover:underline"
+        >
           Inicia sesión
-        </a>
+        </button>
       </p>
     </form>
   );

--- a/app/frontend/src/components/provider/auth/reset-password-form.tsx
+++ b/app/frontend/src/components/provider/auth/reset-password-form.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { FormEvent, useMemo, useState } from "react";
+import Link from "next/link";
+import { ArrowLeft, KeyRound, Lock, Mail } from "lucide-react";
+import { resetPassword } from "@/lib/api/auth";
+import { Button } from "@/components/provider/ui/button";
+import { Input } from "@/components/provider/ui/input";
+import { Label } from "@/components/provider/ui/label";
+import { cn } from "@/components/provider/ui/utils";
+
+interface ResetPasswordFormProps {
+  initialEmail?: string;
+  initialToken?: string;
+}
+
+export function ResetPasswordForm({ initialEmail = "", initialToken = "" }: ResetPasswordFormProps) {
+  const [email, setEmail] = useState(initialEmail);
+  const [token, setToken] = useState(initialToken);
+  const [password, setPassword] = useState("");
+  const [passwordConfirmation, setPasswordConfirmation] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  const isPasswordValid = useMemo(() => password.length >= 8, [password]);
+  const passwordsMatch = useMemo(
+    () => passwordConfirmation.length > 0 && passwordConfirmation === password,
+    [password, passwordConfirmation]
+  );
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    const normalizedEmail = email.trim().toLowerCase();
+    const normalizedToken = token.trim();
+
+    if (!normalizedEmail || !normalizedToken || !password || !passwordConfirmation) {
+      setError("Completa todos los campos para restablecer tu contraseña.");
+      return;
+    }
+
+    if (!emailRegex.test(normalizedEmail)) {
+      setError("Ingresa un correo válido.");
+      return;
+    }
+
+    if (!isPasswordValid) {
+      setError("La nueva contraseña debe tener al menos 8 caracteres.");
+      return;
+    }
+
+    if (!passwordsMatch) {
+      setError("Las contraseñas no coinciden.");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const result = await resetPassword({
+        email: normalizedEmail,
+        token: normalizedToken,
+        password,
+        password_confirmation: passwordConfirmation,
+      });
+
+      setSuccessMessage(result.message || "Password reset successfully.");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "No se pudo restablecer la contraseña.";
+      setError(message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (successMessage) {
+    return (
+      <div className="space-y-4">
+        <div className="rounded-[12px] border border-emerald-200 bg-emerald-50 p-3">
+          <p className="text-sm text-emerald-700">{successMessage}</p>
+        </div>
+
+        <Link href="/provider/login" className="block w-full">
+          <Button
+            type="button"
+            className={cn(
+              "w-full h-[52px] rounded-[14px] text-white font-medium",
+              "bg-[#4B236A] hover:bg-[#5D2B7D]",
+              "transition-all duration-200 shadow-lg hover:shadow-xl"
+            )}
+          >
+            Ir a iniciar sesión
+          </Button>
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <h1 className="text-2xl font-bold tracking-tight text-[#1A1A1A]">Restablecer contraseña</h1>
+        <p className="text-sm text-[#6A6A6A]">
+          Ingresa el correo y token recibido para definir tu nueva contraseña.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="reset-email" className="text-[#1A1A1A] font-semibold">
+          Correo Electrónico
+        </Label>
+        <div className="relative">
+          <Mail className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-gray-400" />
+          <Input
+            id="reset-email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            disabled={loading}
+            className={cn(
+              "pl-10 h-[50px] rounded-[14px] border-[#E0E0E0] placeholder-gray-400",
+              "focus:border-[#4B236A] focus:ring-2 focus:ring-[#4B236A]/20"
+            )}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="reset-token" className="text-[#1A1A1A] font-semibold">
+          Token de Recuperación
+        </Label>
+        <div className="relative">
+          <KeyRound className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-gray-400" />
+          <Input
+            id="reset-token"
+            type="text"
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            disabled={loading}
+            className={cn(
+              "pl-10 h-[50px] rounded-[14px] border-[#E0E0E0] placeholder-gray-400",
+              "focus:border-[#4B236A] focus:ring-2 focus:ring-[#4B236A]/20"
+            )}
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="reset-password" className="text-[#1A1A1A] font-semibold">
+          Nueva Contraseña
+        </Label>
+        <div className="relative">
+          <Lock className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-gray-400" />
+          <Input
+            id="reset-password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            disabled={loading}
+            className={cn(
+              "pl-10 h-[50px] rounded-[14px] border-[#E0E0E0] placeholder-gray-400",
+              "focus:border-[#4B236A] focus:ring-2 focus:ring-[#4B236A]/20"
+            )}
+          />
+        </div>
+        {!isPasswordValid && password.length > 0 && (
+          <p className="text-xs text-red-600">Debe tener al menos 8 caracteres.</p>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="reset-password-confirmation" className="text-[#1A1A1A] font-semibold">
+          Confirmar Contraseña
+        </Label>
+        <div className="relative">
+          <Lock className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-gray-400" />
+          <Input
+            id="reset-password-confirmation"
+            type="password"
+            value={passwordConfirmation}
+            onChange={(e) => setPasswordConfirmation(e.target.value)}
+            disabled={loading}
+            className={cn(
+              "pl-10 h-[50px] rounded-[14px] border-[#E0E0E0] placeholder-gray-400",
+              "focus:border-[#4B236A] focus:ring-2 focus:ring-[#4B236A]/20"
+            )}
+          />
+        </div>
+        {passwordConfirmation.length > 0 && !passwordsMatch && (
+          <p className="text-xs text-red-600">Las contraseñas no coinciden.</p>
+        )}
+      </div>
+
+      {error && (
+        <div className="rounded-[12px] bg-red-50 border border-red-200 p-3">
+          <p className="text-sm text-red-700">{error}</p>
+        </div>
+      )}
+
+      <Button
+        type="submit"
+        disabled={loading}
+        className={cn(
+          "w-full h-[52px] rounded-[14px] text-white font-medium",
+          "bg-[#4B236A] hover:bg-[#5D2B7D]",
+          "disabled:opacity-50 disabled:cursor-not-allowed",
+          "transition-all duration-200 shadow-lg hover:shadow-xl"
+        )}
+      >
+        {loading ? "Restableciendo..." : "Restablecer contraseña"}
+      </Button>
+
+      <Link href="/provider/login" className="mx-auto flex w-fit items-center gap-2 text-sm font-medium text-[#4B236A] hover:underline">
+        <ArrowLeft className="h-4 w-4" />
+        Volver a iniciar sesión
+      </Link>
+    </form>
+  );
+}

--- a/app/frontend/src/lib/api/auth.ts
+++ b/app/frontend/src/lib/api/auth.ts
@@ -16,12 +16,53 @@ type LoginPayload = {
   password: string;
 };
 
+type ForgotPasswordPayload = {
+  email: string;
+};
+
+type ResetPasswordPayload = {
+  email: string;
+  token: string;
+  password: string;
+  password_confirmation: string;
+};
+
 export type LoginResult = {
   ok: true;
   redirectTo?: string;
   user?: SessionData;
   token?: string;
 };
+
+export type ForgotPasswordResult = {
+  ok: true;
+  message: string;
+};
+
+export type ResetPasswordResult = {
+  ok: true;
+  message: string;
+};
+
+type BasicApiResponse = {
+  status?: boolean;
+  message?: string;
+};
+
+function extractApiMessage(payload: unknown, fallback: string): string {
+  if (payload && typeof payload === "object" && "message" in payload) {
+    const value = (payload as { message?: unknown }).message;
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+  }
+
+  return fallback;
+}
+
+async function readErrorBody(response: Response): Promise<unknown> {
+  return await response.json().catch(() => null);
+}
 
 // ============================================
 // API Functions
@@ -106,6 +147,118 @@ export async function login({ email, password }: LoginPayload): Promise<LoginRes
     }
     
     // Error genérico de red u otros
+    throw new ApiError("No se pudo conectar con el servidor", 0, error);
+  }
+}
+
+/**
+ * POST /api/v1/password/forgot
+ * Solicita correo de recuperación para una cuenta existente.
+ */
+export async function requestPasswordReset({ email }: ForgotPasswordPayload): Promise<ForgotPasswordResult> {
+  const normalizedEmail = email.trim().toLowerCase();
+
+  if (!normalizedEmail) {
+    throw new ApiError("Ingresa un correo electrónico.", 422);
+  }
+
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedEmail)) {
+    throw new ApiError("Ingresa un correo válido.", 422);
+  }
+
+  try {
+    const response = await fetch(`${API_URL}/api/v1/password/forgot`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({ email: normalizedEmail }),
+    });
+
+    if (!response.ok) {
+      const errorData = await readErrorBody(response);
+      const apiMessage = extractApiMessage(errorData, "No se pudo enviar el correo de recuperación.");
+      throw new ApiError(apiMessage, response.status, errorData);
+    }
+
+    const data = (await response.json().catch(() => null)) as BasicApiResponse | null;
+    const message = extractApiMessage(data, "Recovery email sent successfully.");
+
+    return {
+      ok: true,
+      message,
+    };
+  } catch (error) {
+    if (error instanceof ApiError) {
+      throw error;
+    }
+
+    if (error instanceof Error) {
+      throw new ApiError(error.message || "Error del servidor", 0, error);
+    }
+
+    throw new ApiError("No se pudo conectar con el servidor", 0, error);
+  }
+}
+
+/**
+ * POST /api/v1/password/reset
+ * Restablece contraseña usando token enviado al correo.
+ */
+export async function resetPassword({
+  email,
+  token,
+  password,
+  password_confirmation,
+}: ResetPasswordPayload): Promise<ResetPasswordResult> {
+  const normalizedEmail = email.trim().toLowerCase();
+
+  if (!normalizedEmail || !token.trim() || !password || !password_confirmation) {
+    throw new ApiError("Completa todos los campos.", 422);
+  }
+
+  if (password !== password_confirmation) {
+    throw new ApiError("Las contraseñas no coinciden.", 422);
+  }
+
+  try {
+    const response = await fetch(`${API_URL}/api/v1/password/reset`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({
+        email: normalizedEmail,
+        token: token.trim(),
+        password,
+        password_confirmation,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorData = await readErrorBody(response);
+      const apiMessage = extractApiMessage(errorData, "No se pudo restablecer la contraseña.");
+      throw new ApiError(apiMessage, response.status, errorData);
+    }
+
+    const data = (await response.json().catch(() => null)) as BasicApiResponse | null;
+    const message = extractApiMessage(data, "Password reset successfully.");
+
+    return {
+      ok: true,
+      message,
+    };
+  } catch (error) {
+    if (error instanceof ApiError) {
+      throw error;
+    }
+
+    if (error instanceof Error) {
+      throw new ApiError(error.message || "Error del servidor", 0, error);
+    }
+
     throw new ApiError("No se pudo conectar con el servidor", 0, error);
   }
 }

--- a/app/frontend/src/lib/api/index.ts
+++ b/app/frontend/src/lib/api/index.ts
@@ -15,8 +15,8 @@ export type { ApiSuccess, PaginatedApiResponse, PaginationMeta, PaginationLinks 
 export { API_URL, ApiError, getAuthHeaders, fetchWithErrorHandling } from "./client";
 
 // Authentication
-export { login, logout } from "./auth";
-export type { LoginResult } from "./auth";
+export { login, logout, requestPasswordReset, resetPassword } from "./auth";
+export type { LoginResult, ForgotPasswordResult, ResetPasswordResult } from "./auth";
 
 // Provider Authentication
 export { registerProvider } from "./provider-auth";

--- a/app/frontend/src/proxy.ts
+++ b/app/frontend/src/proxy.ts
@@ -2,7 +2,7 @@ import { NextResponse, type NextRequest } from "next/server";
 
 const SESSION_COOKIE = "sdjr_session";
 const BYPASS_AUTH = process.env.NEXT_PUBLIC_BYPASS_AUTH === "true";
-const PUBLIC_ROUTES = ["/admin/login", "/provider/login", "/app/login"];
+const PUBLIC_ROUTES = ["/admin/login", "/provider/login", "/app/login", "/reset-password"];
 const LOGIN_BY_SEGMENT: Record<string, string> = {
   admin: "/admin/login",
   provider: "/provider/login",

--- a/app/frontend/src/types/commerces.adapters.ts
+++ b/app/frontend/src/types/commerces.adapters.ts
@@ -72,7 +72,7 @@ export const commerceToProveedor = (commerce: CommerceFromAPI): Proveedor => {
     representanteLegal: representanteLegal.trim(),
     tipoDocumentoRepresentante: commerce.legal_representatives?.[0]?.document_type === 'CC' ? 'Cédula de ciudadanía' : (commerce.legal_representatives?.[0]?.document_type === 'CE' ? 'Cédula de extranjería' : (commerce.legal_representatives?.[0]?.document_type === 'PAS' ? 'Pasaporte' : 'Cédula de ciudadanía')),
     documentoRepresentante: commerce.legal_representatives?.[0]?.document || '',
-    tipoEstablecimiento: 'Comercial', // TODO: Obtener del backend si está disponible
+    tipoEstablecimiento: commerce.establishment_type?.name || '', // TODO: Obtener del backend si está disponible
     telefono: commerce.phone || '',
     email: commerce.email || '',
     departamento: commerce.department?.name || '',


### PR DESCRIPTION
Este PR implementa el flujo funcional de recuperación y restablecimiento de contraseña en frontend, alineado con los endpoints públicos del backend, y agrega dos ajustes puntuales en datos de proveedor para consistencia de formulario y mapeo.

## Cambios principales
1. Se reemplazan enlaces sin acción en login/registro por navegación funcional dentro del flujo de autenticación.
2. Se agrega panel de recuperación de contraseña en el auth de proveedor.
3. Se agrega formulario de restablecimiento de contraseña y nueva ruta pública para consumir token y email desde query params.
4. Se agregan funciones API para:
   - POST /api/v1/password/forgot
   - POST /api/v1/password/reset
5. Se actualiza el proxy/middleware para permitir acceso público a /reset-password.
6. Ajustes de proveedor:
   - Corrección de campo de documento de representante legal.
   - Uso de establishment_type.name en adaptador de comercios.

## Impacto
1. Usuarios proveedor ya pueden iniciar flujo real de recuperación desde frontend.
2. El link de correo con token/email apunta a una vista funcional en frontend.
3. Se mejora consistencia de datos mostrados en el módulo de proveedor.

## Validación
1. Endpoints forgot/reset integrados desde frontend.
2. Ruta pública /reset-password habilitada en proxy.
3. Flujo de email verificado en entorno local con mailer en modo log.