### PR TITLE
feat(products): validar stock disponible para creacion/edicion de packs

### DIFF
--- a/app/backend/app/Http/Requests/Api/V1/StoreProductRequest.php
+++ b/app/backend/app/Http/Requests/Api/V1/StoreProductRequest.php
@@ -7,6 +7,7 @@ namespace App\Http\Requests\Api\V1;
 use App\Constants\Constant;
 use App\Models\Commerce;
 use App\Models\Product;
+use App\Services\PackageAvailabilityCalculator;
 use App\Services\ProductService;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
@@ -120,20 +121,59 @@ class StoreProductRequest extends FormRequest
     public function withValidator(Validator $validator): void
     {
         $validator->after(function ($validator) {
-            if ($this->has('package_items')) {
-                foreach ($this->input('package_items', []) as $index => $item) {
-                    if (isset($item['product_id']) && isset($item['quantity'])) {
-                        $product = Product::find($item['product_id']);
-                        if ($product) {
-                            if ($item['quantity'] > $product->quantity_available) {
-                                $validator->errors()->add(
-                                    "package_items.{$index}.quantity",
-                                    "The quantity cannot exceed the available quantity ({$product->quantity_available}) of product '{$product->title}'."
-                                );
-                            }
-                        }
-                    }
+            // TODO: For product_type=single, only the basic rules() (types/ranges/existence) are
+            // enforced. No cross-field business validation is performed (e.g. discounted_price <
+            // original_price, quantity_available <= quantity_total). Analyze in a future task.
+            if (! $this->has('package_items')) {
+                return;
+            }
+
+            $packageItems = collect();
+
+            foreach ($this->input('package_items', []) as $index => $item) {
+                if (! isset($item['product_id'], $item['quantity'])) {
+                    continue;
                 }
+
+                $product = Product::find($item['product_id']);
+
+                if (! $product) {
+                    continue;
+                }
+
+                if ($product->product_type !== Constant::PRODUCT_TYPE_SINGLE) {
+                    $validator->errors()->add(
+                        "package_items.{$index}.product_id",
+                        "The product '{$product->title}' must be of type 'single' to be included in a package."
+                    );
+
+                    continue;
+                }
+
+                if ($item['quantity'] > $product->quantity_available) {
+                    $validator->errors()->add(
+                        "package_items.{$index}.quantity",
+                        "The quantity cannot exceed the available quantity ({$product->quantity_available}) of product '{$product->title}'."
+                    );
+
+                    continue;
+                }
+
+                $packageItems->push(['product' => $product, 'quantity' => (int) $item['quantity']]);
+            }
+
+            if ($packageItems->isEmpty() || $this->input('product.product_type') !== Constant::PRODUCT_TYPE_PACKAGE) {
+                return;
+            }
+
+            $maxPacks = app(PackageAvailabilityCalculator::class)->maxPackageQuantity($packageItems);
+            $requestedPacks = (int) $this->input('product.quantity_available');
+
+            if ($requestedPacks > $maxPacks) {
+                $validator->errors()->add(
+                    'product.quantity_available',
+                    "The requested quantity_available ({$requestedPacks}) exceeds the maximum packs available given current stock (max: {$maxPacks})."
+                );
             }
         });
     }

--- a/app/backend/app/Http/Requests/Api/V1/UpdateProductRequest.php
+++ b/app/backend/app/Http/Requests/Api/V1/UpdateProductRequest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Http\Requests\Api\V1;
 
+use App\Constants\Constant;
 use App\Models\Commerce;
 use App\Models\Product;
+use App\Services\PackageAvailabilityCalculator;
 use App\Services\ProductService;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
@@ -110,20 +112,65 @@ class UpdateProductRequest extends FormRequest
     public function withValidator(Validator $validator): void
     {
         $validator->after(function ($validator) {
-            if ($this->has('package_items')) {
-                foreach ($this->input('package_items', []) as $index => $item) {
-                    if (isset($item['product_id']) && isset($item['quantity'])) {
-                        $product = Product::find($item['product_id']);
-                        if ($product) {
-                            if ($item['quantity'] > $product->quantity_available) {
-                                $validator->errors()->add(
-                                    "package_items.{$index}.quantity",
-                                    "The quantity cannot exceed the available quantity ({$product->quantity_available}) of product '{$product->title}'."
-                                );
-                            }
-                        }
-                    }
+            // TODO: For product_type=single, only the basic rules() (types/ranges/existence) are
+            // enforced. No cross-field business validation is performed (e.g. discounted_price <
+            // original_price, quantity_available <= quantity_total). Analyze in a future task.
+            if (! $this->has('package_items')) {
+                return;
+            }
+
+            $routeParameters = $this->route()?->parameters() ?? [];
+            $currentPackageId = $routeParameters !== [] ? (int) reset($routeParameters) : null;
+            $existingPackage = $currentPackageId ? Product::find($currentPackageId) : null;
+
+            $packageItems = collect();
+
+            foreach ($this->input('package_items', []) as $index => $item) {
+                if (! isset($item['product_id'], $item['quantity'])) {
+                    continue;
                 }
+
+                $product = Product::find($item['product_id']);
+
+                if (! $product) {
+                    continue;
+                }
+
+                if ($product->product_type !== Constant::PRODUCT_TYPE_SINGLE) {
+                    $validator->errors()->add(
+                        "package_items.{$index}.product_id",
+                        "The product '{$product->title}' must be of type 'single' to be included in a package."
+                    );
+
+                    continue;
+                }
+
+                if ($item['quantity'] > $product->quantity_available) {
+                    $validator->errors()->add(
+                        "package_items.{$index}.quantity",
+                        "The quantity cannot exceed the available quantity ({$product->quantity_available}) of product '{$product->title}'."
+                    );
+
+                    continue;
+                }
+
+                $packageItems->push(['product' => $product, 'quantity' => (int) $item['quantity']]);
+            }
+
+            $productType = $this->input('product.product_type', $existingPackage?->product_type);
+
+            if ($packageItems->isEmpty() || $productType !== Constant::PRODUCT_TYPE_PACKAGE) {
+                return;
+            }
+
+            $maxPacks = app(PackageAvailabilityCalculator::class)->maxPackageQuantity($packageItems, $currentPackageId);
+            $requestedPacks = (int) $this->input('product.quantity_available', $existingPackage?->quantity_available ?? 0);
+
+            if ($requestedPacks > $maxPacks) {
+                $validator->errors()->add(
+                    'product.quantity_available',
+                    "The requested quantity_available ({$requestedPacks}) exceeds the maximum packs available given current stock (max: {$maxPacks})."
+                );
             }
         });
     }

--- a/app/backend/app/Http/Resources/Api/V1/ProductResource.php
+++ b/app/backend/app/Http/Resources/Api/V1/ProductResource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Resources\Api\V1;
 
+use App\Constants\Constant;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 /**
@@ -21,6 +22,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *   @OA\Property(property="discounted_price", type="number", format="float", nullable=true),
  *   @OA\Property(property="quantity_total", type="integer"),
  *   @OA\Property(property="quantity_available", type="integer"),
+ *   @OA\Property(property="available_for_packaging", type="integer", nullable=true, description="Stock still available to be committed to packages (only present for product_type=single)"),
  *   @OA\Property(property="expires_at", type="string", format="date-time", nullable=true),
  *   @OA\Property(property="photos", type="array", @OA\Items(ref="#/components/schemas/DocumentUploadResource")),
  *   @OA\Property(
@@ -65,6 +67,10 @@ class ProductResource extends JsonResource
             'discounted_price' => $this->discounted_price,
             'quantity_total' => $this->quantity_total,
             'quantity_available' => $this->quantity_available,
+            'available_for_packaging' => $this->when(
+                $this->product_type === Constant::PRODUCT_TYPE_SINGLE,
+                fn () => $this->available_for_packaging
+            ),
             'expires_at' => $this->expires_at,
             'photos' => $this->whenLoaded('photos', function () {
                 return $this->photos->map(function ($photo) {

--- a/app/backend/app/Models/Product.php
+++ b/app/backend/app/Models/Product.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use App\Constants\Constant;
 use App\Models\Traits\SanitizesTextAttributes;
+use App\Services\PackageAvailabilityCalculator;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -91,6 +92,15 @@ class Product extends Model
         })->where('product_id', $this->id)->sum('quantity');
 
         return (int) $this->attributes['quantity_available'] - intval($reservedQuantity);
+    }
+
+    /**
+     * Get the stock of this product still available to be committed to packages,
+     * after subtracting the stock already committed by packages that include it.
+     */
+    public function getAvailableForPackagingAttribute(): int
+    {
+        return app(PackageAvailabilityCalculator::class)->availableForPackaging($this);
     }
 
     /**

--- a/app/backend/app/Services/PackageAvailabilityCalculator.php
+++ b/app/backend/app/Services/PackageAvailabilityCalculator.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Constants\Constant;
+use App\Models\OrderItem;
+use App\Models\Product;
+use Illuminate\Support\Collection;
+
+/**
+ * Service class for calculating package (pack) stock availability.
+ *
+ * Computes, in real time, how many units of a single product remain
+ * available to be committed to packages, and how many packs a given
+ * combination of items can support given current stock and existing
+ * commitments from other packs.
+ */
+class PackageAvailabilityCalculator
+{
+    /**
+     * Get the stock of a single product that is still available to be
+     * committed to packages, after subtracting the stock already
+     * committed by packages that include it.
+     *
+     * @param  Product  $product  A product with product_type "single".
+     * @param  int|null  $excludePackageId  Exclude this package's own commitment from the calculation (used when editing a pack).
+     */
+    public function availableForPackaging(Product $product, ?int $excludePackageId = null): int
+    {
+        $product->loadMissing('package');
+
+        $packages = $product->package
+            ->when(
+                $excludePackageId !== null,
+                fn (Collection $packages) => $packages->reject(
+                    fn (Product $package) => $package->id === $excludePackageId
+                )
+            );
+
+        // Resolve the active-order reservations for all involved packages with a single
+        // aggregate query, instead of relying on Product::quantity_available's per-model query.
+        $reservedQuantities = $this->reservedQuantitiesByProductId($packages->pluck('id'));
+
+        $committedStock = $packages->sum(function (Product $package) use ($reservedQuantities) {
+            $effectiveQuantityAvailable = (int) $package->getAttributes()['quantity_available']
+                - $reservedQuantities->get($package->id, 0);
+
+            return $effectiveQuantityAvailable * (int) $package->pivot->quantity;
+        });
+
+        return max(0, $product->quantity_available - $committedStock);
+    }
+
+    /**
+     * Get the maximum number of packs that can be offered given the
+     * available stock of each component product.
+     *
+     * @param  Collection<int, array{product: Product, quantity: int}>  $packageItems  Each entry pairs a component product with the quantity required per pack.
+     * @param  int|null  $excludePackageId  Exclude this package's own commitment from the calculation (used when editing a pack).
+     */
+    public function maxPackageQuantity(Collection $packageItems, ?int $excludePackageId = null): int
+    {
+        if ($packageItems->isEmpty()) {
+            return 0;
+        }
+
+        return (int) $packageItems
+            ->map(function (array $item) use ($excludePackageId) {
+                $quantity = (int) $item['quantity'];
+
+                if ($quantity <= 0) {
+                    return 0;
+                }
+
+                return intdiv($this->availableForPackaging($item['product'], $excludePackageId), $quantity);
+            })
+            ->min();
+    }
+
+    /**
+     * Get the quantity reserved by active orders for each of the given product IDs,
+     * in a single aggregate query.
+     *
+     * @param  Collection<int, int>  $productIds
+     * @return Collection<int, int> Reserved quantity keyed by product ID.
+     */
+    private function reservedQuantitiesByProductId(Collection $productIds): Collection
+    {
+        if ($productIds->isEmpty()) {
+            return collect();
+        }
+
+        return OrderItem::whereHas('order', function ($query) {
+            $query->whereIn('status', [
+                Constant::ORDER_STATUS_PENDING,
+                Constant::ORDER_STATUS_PREPARING,
+                Constant::ORDER_STATUS_READY,
+            ]);
+        })
+            ->whereIn('product_id', $productIds)
+            ->selectRaw('product_id, SUM(quantity) as total')
+            ->groupBy('product_id')
+            ->get()
+            ->mapWithKeys(fn ($row) => [(int) $row->product_id => (int) $row->total]);
+    }
+}

--- a/app/backend/app/Services/ProductService.php
+++ b/app/backend/app/Services/ProductService.php
@@ -221,7 +221,7 @@ class ProductService
     public function getByCommerce(int $commerce_id)
     {
         try {
-            return Product::with(['photos', 'packageItems', 'packageItems.photos'])
+            return Product::with(['photos', 'packageItems', 'packageItems.photos', 'package'])
                 ->where('commerce_id', $commerce_id)
                 ->get();
         } catch (ModelNotFoundException $e) {
@@ -237,7 +237,7 @@ class ProductService
      */
     public function getByCommerceBranch(int $branch_id)
     {
-        $products = Product::with(['photos', 'packageItems', 'packageItems.photos'])
+        $products = Product::with(['photos', 'packageItems', 'packageItems.photos', 'package'])
             ->whereHas('commerce.commerceBranches', function ($query) use ($branch_id) {
                 $query->where('id', $branch_id);
             })->get();

--- a/app/backend/tests/Feature/Api/V1/ProductFeatureTest.php
+++ b/app/backend/tests/Feature/Api/V1/ProductFeatureTest.php
@@ -11,6 +11,7 @@ use App\Models\Product;
 use App\Models\ProductCategory;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Spatie\Permission\Models\Permission;
 use Tests\TestCase;
 
@@ -435,6 +436,8 @@ class ProductFeatureTest extends TestCase
         $package = Product::factory()->create([
             'commerce_id' => $commerce->id,
             'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+            'quantity_total' => 2,
+            'quantity_available' => 2,
         ]);
         $product = Product::factory()->create([
             'commerce_id' => $package->commerce_id,
@@ -555,5 +558,323 @@ class ProductFeatureTest extends TestCase
         $response = $this->putJson('/api/v1/products/commerce/package-items/'.$package->id, $payload);
         $response->assertStatus(422)
             ->assertJsonValidationErrors(['package_items.0.quantity']);
+    }
+
+    public function test_store_package_items_within_max_packs_succeeds()
+    {
+        $user = $this->actingAsAdmin();
+        $commerce = Commerce::factory()->create(['owner_user_id' => $user->id]);
+        $commerceBranch = CommerceBranch::factory()->create(['commerce_id' => $commerce->id]);
+        $category = ProductCategory::factory()->create();
+        $product = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'quantity_total' => 10,
+            'quantity_available' => 10,
+        ]);
+
+        $payload = [
+            'product' => [
+                'commerce_id' => $commerce->id,
+                'product_category_id' => $category->id,
+                'title' => 'Test Package',
+                'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+                'original_price' => 100,
+                'quantity_total' => 5,
+                'quantity_available' => 5, // max packs = floor(10 / 2) = 5
+            ],
+            'package_items' => [
+                ['product_id' => $product->id, 'quantity' => 2],
+            ],
+            'commerce_branch_ids' => [$commerceBranch->id],
+        ];
+
+        $response = $this->postJson('/api/v1/products/commerce/package-items', $payload);
+        $response->assertOk();
+    }
+
+    public function test_store_package_items_rejects_quantity_available_exceeding_max_packs()
+    {
+        $user = $this->actingAsAdmin();
+        $commerce = Commerce::factory()->create(['owner_user_id' => $user->id]);
+        $commerceBranch = CommerceBranch::factory()->create(['commerce_id' => $commerce->id]);
+        $category = ProductCategory::factory()->create();
+        $product = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'quantity_total' => 10,
+            'quantity_available' => 10,
+        ]);
+
+        $payload = [
+            'product' => [
+                'commerce_id' => $commerce->id,
+                'product_category_id' => $category->id,
+                'title' => 'Test Package',
+                'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+                'original_price' => 100,
+                'quantity_total' => 6,
+                'quantity_available' => 6, // max packs = floor(10 / 2) = 5
+            ],
+            'package_items' => [
+                ['product_id' => $product->id, 'quantity' => 2],
+            ],
+            'commerce_branch_ids' => [$commerceBranch->id],
+        ];
+
+        $response = $this->postJson('/api/v1/products/commerce/package-items', $payload);
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['product.quantity_available'])
+            ->assertJsonFragment([
+                'product.quantity_available' => [
+                    'The requested quantity_available (6) exceeds the maximum packs available given current stock (max: 5).',
+                ],
+            ]);
+    }
+
+    public function test_store_package_items_rejects_package_type_product_as_item()
+    {
+        $user = $this->actingAsAdmin();
+        $commerce = Commerce::factory()->create(['owner_user_id' => $user->id]);
+        $commerceBranch = CommerceBranch::factory()->create(['commerce_id' => $commerce->id]);
+        $category = ProductCategory::factory()->create();
+        $existingPackage = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+        ]);
+
+        $payload = [
+            'product' => [
+                'commerce_id' => $commerce->id,
+                'product_category_id' => $category->id,
+                'title' => 'Test Package',
+                'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+                'original_price' => 100,
+                'quantity_total' => 1,
+                'quantity_available' => 1,
+            ],
+            'package_items' => [
+                ['product_id' => $existingPackage->id, 'quantity' => 1],
+            ],
+            'commerce_branch_ids' => [$commerceBranch->id],
+        ];
+
+        $response = $this->postJson('/api/v1/products/commerce/package-items', $payload);
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['package_items.0.product_id']);
+    }
+
+    public function test_update_package_items_within_new_max_packs_succeeds()
+    {
+        $user = $this->actingAsAdmin();
+        $commerce = Commerce::factory()->create(['owner_user_id' => $user->id]);
+        $commerceBranch = CommerceBranch::factory()->create(['commerce_id' => $commerce->id]);
+        $product = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'quantity_total' => 10,
+            'quantity_available' => 10,
+        ]);
+        $package = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+            'quantity_total' => 5,
+            'quantity_available' => 5,
+        ]);
+        $package->packageItems()->attach($product->id, ['quantity' => 2]);
+
+        $payload = [
+            'product' => [
+                'commerce_id' => $commerce->id,
+                // own previous commitment (5 * 2 = 10) is excluded, so available stays 10.
+                // New max packs = floor(10 / 5) = 2.
+                'quantity_available' => 2,
+            ],
+            'package_items' => [
+                ['product_id' => $product->id, 'quantity' => 5],
+            ],
+            'commerce_branch_ids' => [$commerceBranch->id],
+        ];
+
+        $response = $this->putJson('/api/v1/products/commerce/package-items/'.$package->id, $payload);
+        $response->assertOk();
+
+        $this->assertEquals(2, $package->fresh()->quantity_available);
+        $this->assertEquals(5, $package->fresh()->packageItems()->first()->pivot->quantity);
+    }
+
+    public function test_update_package_items_rejects_quantity_available_exceeding_new_max_packs()
+    {
+        $user = $this->actingAsAdmin();
+        $commerce = Commerce::factory()->create(['owner_user_id' => $user->id]);
+        $commerceBranch = CommerceBranch::factory()->create(['commerce_id' => $commerce->id]);
+        $product = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'quantity_total' => 10,
+            'quantity_available' => 10,
+        ]);
+        $package = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+            'quantity_total' => 5,
+            'quantity_available' => 5,
+        ]);
+        $package->packageItems()->attach($product->id, ['quantity' => 2]);
+
+        $payload = [
+            'product' => [
+                'commerce_id' => $commerce->id,
+                // own previous commitment (5 * 2 = 10) is excluded, so available stays 10.
+                // New max packs = floor(10 / 5) = 2, but 3 is requested.
+                'quantity_available' => 3,
+            ],
+            'package_items' => [
+                ['product_id' => $product->id, 'quantity' => 5],
+            ],
+            'commerce_branch_ids' => [$commerceBranch->id],
+        ];
+
+        $response = $this->putJson('/api/v1/products/commerce/package-items/'.$package->id, $payload);
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['product.quantity_available'])
+            ->assertJsonFragment([
+                'product.quantity_available' => [
+                    'The requested quantity_available (3) exceeds the maximum packs available given current stock (max: 2).',
+                ],
+            ]);
+    }
+
+    public function test_store_package_items_respects_remainder_committed_by_other_packs()
+    {
+        $user = $this->actingAsAdmin();
+        $commerce = Commerce::factory()->create(['owner_user_id' => $user->id]);
+        $commerceBranch = CommerceBranch::factory()->create(['commerce_id' => $commerce->id]);
+        $category = ProductCategory::factory()->create();
+        $product = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'quantity_total' => 10,
+            'quantity_available' => 10,
+        ]);
+
+        // Pack A already commits 2 packs * 3 units = 6 units, leaving a remainder of 4.
+        $packA = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+            'quantity_total' => 2,
+            'quantity_available' => 2,
+        ]);
+        $packA->packageItems()->attach($product->id, ['quantity' => 3]);
+
+        $basePayload = [
+            'product' => [
+                'commerce_id' => $commerce->id,
+                'product_category_id' => $category->id,
+                'title' => 'Pack B',
+                'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+                'original_price' => 100,
+                'quantity_total' => 3,
+            ],
+            'package_items' => [
+                ['product_id' => $product->id, 'quantity' => 2],
+            ],
+            'commerce_branch_ids' => [$commerceBranch->id],
+        ];
+
+        // Remainder = 4 units, requested item quantity = 2 -> max packs = floor(4 / 2) = 2.
+        $exceedingPayload = $basePayload;
+        $exceedingPayload['product']['quantity_available'] = 3;
+
+        $response = $this->postJson('/api/v1/products/commerce/package-items', $exceedingPayload);
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['product.quantity_available'])
+            ->assertJsonFragment([
+                'product.quantity_available' => [
+                    'The requested quantity_available (3) exceeds the maximum packs available given current stock (max: 2).',
+                ],
+            ]);
+
+        $withinRemainderPayload = $basePayload;
+        $withinRemainderPayload['product']['quantity_available'] = 2;
+
+        $response = $this->postJson('/api/v1/products/commerce/package-items', $withinRemainderPayload);
+        $response->assertOk();
+    }
+
+    public function test_product_resource_exposes_available_for_packaging_for_single_products_only()
+    {
+        $this->actingAsAdmin();
+        $commerce = Commerce::factory()->create();
+        $product = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'quantity_total' => 10,
+            'quantity_available' => 10,
+        ]);
+
+        $package = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+            'quantity_total' => 3,
+            'quantity_available' => 3,
+        ]);
+        $package->packageItems()->attach($product->id, ['quantity' => 2]);
+
+        // Single product: 10 - (3 packs * 2 units) = 4
+        $singleResponse = $this->getJson('/api/v1/products/'.$product->id);
+        $singleResponse->assertOk()->assertJsonPath('data.available_for_packaging', 4);
+
+        $packageResponse = $this->getJson('/api/v1/products/'.$package->id);
+        $packageResponse->assertOk();
+        $this->assertArrayNotHasKey('available_for_packaging', $packageResponse->json('data'));
+    }
+
+    public function test_available_for_packaging_does_not_n_plus_one_per_associated_package()
+    {
+        $this->actingAsAdmin();
+        $commerce = Commerce::factory()->create();
+        $product = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'quantity_total' => 100,
+            'quantity_available' => 100,
+        ]);
+
+        $packA = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+            'quantity_total' => 1,
+            'quantity_available' => 1,
+        ]);
+        $packA->packageItems()->attach($product->id, ['quantity' => 1]);
+
+        // Warm up permission/model caches so they do not skew the query count comparison below.
+        $this->getJson('/api/v1/products/'.$product->id)->assertOk();
+
+        DB::enableQueryLog();
+        $this->getJson('/api/v1/products/'.$product->id)->assertOk();
+        $queryCountForOnePackage = count(DB::getQueryLog());
+        DB::flushQueryLog();
+        DB::disableQueryLog();
+
+        $packB = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+            'quantity_total' => 1,
+            'quantity_available' => 1,
+        ]);
+        $packC = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+            'quantity_total' => 1,
+            'quantity_available' => 1,
+        ]);
+        $packB->packageItems()->attach($product->id, ['quantity' => 1]);
+        $packC->packageItems()->attach($product->id, ['quantity' => 1]);
+
+        DB::enableQueryLog();
+        $this->getJson('/api/v1/products/'.$product->id)->assertOk();
+        $queryCountForThreePackages = count(DB::getQueryLog());
+        DB::disableQueryLog();
+
+        $this->assertSame(
+            $queryCountForOnePackage,
+            $queryCountForThreePackages,
+            'Computing available_for_packaging should issue the same number of queries regardless of how many packages reference the product (no N+1 per package).'
+        );
     }
 }

--- a/app/backend/tests/Unit/Api/V1/PackageAvailabilityCalculatorTest.php
+++ b/app/backend/tests/Unit/Api/V1/PackageAvailabilityCalculatorTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Api\V1;
+
+use App\Constants\Constant;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Product;
+use App\Services\PackageAvailabilityCalculator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use Tests\TestCase;
+
+class PackageAvailabilityCalculatorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_available_for_packaging_without_packs_equals_quantity_available(): void
+    {
+        $calculator = new PackageAvailabilityCalculator;
+
+        $product = Product::factory()->create([
+            'quantity_total' => 10,
+            'quantity_available' => 10,
+        ]);
+
+        $this->assertEquals(10, $calculator->availableForPackaging($product));
+    }
+
+    public function test_available_for_packaging_with_one_pack_subtracts_committed_stock(): void
+    {
+        $calculator = new PackageAvailabilityCalculator;
+
+        $product = Product::factory()->create([
+            'quantity_total' => 10,
+            'quantity_available' => 10,
+        ]);
+
+        $pack = Product::factory()->create([
+            'commerce_id' => $product->commerce_id,
+            'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+            'quantity_total' => 3,
+            'quantity_available' => 3,
+        ]);
+
+        $pack->packageItems()->attach($product->id, ['quantity' => 2]);
+
+        // 10 - (3 packs * 2 units each) = 4
+        $this->assertEquals(4, $calculator->availableForPackaging($product->fresh()));
+    }
+
+    public function test_available_for_packaging_with_multiple_packs_sums_committed_stock(): void
+    {
+        $calculator = new PackageAvailabilityCalculator;
+
+        $product = Product::factory()->create([
+            'quantity_total' => 20,
+            'quantity_available' => 20,
+        ]);
+
+        $packA = Product::factory()->create([
+            'commerce_id' => $product->commerce_id,
+            'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+            'quantity_total' => 3,
+            'quantity_available' => 3,
+        ]);
+        $packA->packageItems()->attach($product->id, ['quantity' => 2]);
+
+        $packB = Product::factory()->create([
+            'commerce_id' => $product->commerce_id,
+            'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+            'quantity_total' => 2,
+            'quantity_available' => 2,
+        ]);
+        $packB->packageItems()->attach($product->id, ['quantity' => 1]);
+
+        // 20 - (3*2 + 2*1) = 20 - 8 = 12
+        $this->assertEquals(12, $calculator->availableForPackaging($product->fresh()));
+    }
+
+    public function test_available_for_packaging_with_exclude_package_id_excludes_own_commitment(): void
+    {
+        $calculator = new PackageAvailabilityCalculator;
+
+        $product = Product::factory()->create([
+            'quantity_total' => 10,
+            'quantity_available' => 10,
+        ]);
+
+        $packA = Product::factory()->create([
+            'commerce_id' => $product->commerce_id,
+            'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+            'quantity_total' => 3,
+            'quantity_available' => 3,
+        ]);
+        $packA->packageItems()->attach($product->id, ['quantity' => 2]);
+
+        $packB = Product::factory()->create([
+            'commerce_id' => $product->commerce_id,
+            'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+            'quantity_total' => 2,
+            'quantity_available' => 2,
+        ]);
+        $packB->packageItems()->attach($product->id, ['quantity' => 1]);
+
+        // Excluding packA's own commitment: 10 - (2*1) = 8
+        $this->assertEquals(
+            8,
+            $calculator->availableForPackaging($product->fresh(), $packA->id)
+        );
+    }
+
+    public function test_available_for_packaging_never_returns_negative(): void
+    {
+        $calculator = new PackageAvailabilityCalculator;
+
+        $product = Product::factory()->create([
+            'quantity_total' => 10,
+            'quantity_available' => 10,
+        ]);
+
+        $pack = Product::factory()->create([
+            'commerce_id' => $product->commerce_id,
+            'product_type' => Constant::PRODUCT_TYPE_PACKAGE,
+            'quantity_total' => 10,
+            'quantity_available' => 10,
+        ]);
+
+        // 10 packs * 2 units = 20 committed, more than the 10 available
+        $pack->packageItems()->attach($product->id, ['quantity' => 2]);
+
+        $this->assertEquals(0, $calculator->availableForPackaging($product->fresh()));
+    }
+
+    public function test_available_for_packaging_considers_active_order_reservations(): void
+    {
+        $calculator = new PackageAvailabilityCalculator;
+
+        $product = Product::factory()->create([
+            'quantity_total' => 10,
+            'quantity_available' => 10,
+        ]);
+
+        $order = Order::factory()->create(['status' => Constant::ORDER_STATUS_PENDING]);
+        OrderItem::factory()->create([
+            'order_id' => $order->id,
+            'product_id' => $product->id,
+            'quantity' => 3,
+        ]);
+
+        // quantity_available accessor: 10 - 3 reserved = 7, no packs committed
+        $this->assertEquals(7, $calculator->availableForPackaging($product->fresh()));
+    }
+
+    public function test_max_package_quantity_with_multiple_items_is_governed_by_the_minimum(): void
+    {
+        $calculator = new PackageAvailabilityCalculator;
+
+        $productA = Product::factory()->create([
+            'quantity_total' => 10,
+            'quantity_available' => 10,
+        ]);
+        $productB = Product::factory()->create([
+            'commerce_id' => $productA->commerce_id,
+            'quantity_total' => 9,
+            'quantity_available' => 9,
+        ]);
+
+        $packageItems = new Collection([
+            ['product' => $productA, 'quantity' => 2], // 10 / 2 = 5 possible packs
+            ['product' => $productB, 'quantity' => 2], // 9 / 2 = 4 possible packs
+        ]);
+
+        $this->assertEquals(4, $calculator->maxPackageQuantity($packageItems));
+    }
+}

--- a/app/frontend/src/components/provider/products/form/product-form.tsx
+++ b/app/frontend/src/components/provider/products/form/product-form.tsx
@@ -65,6 +65,7 @@ export function ProductForm({
         title: product.title,
         originalPrice: product.original_price,
         quantityAvailable: product.quantity_available,
+        availableForPackaging: product.available_for_packaging ?? product.quantity_available,
       }));
   }, [availableSingleProducts]);
 
@@ -86,6 +87,7 @@ export function ProductForm({
     branchId,
     setBranchId,
     packageItems,
+    maxPacks,
     mergedErrors,
     handleTogglePackItem,
     handlePackItemQuantityChange,
@@ -226,6 +228,18 @@ export function ProductForm({
         onChange={(event) => setQuantityAvailable(event.target.value)}
         disabled={submitting}
         error={mergedErrors.quantityAvailable}
+        helperText={
+          productType === "package" && maxPacks !== undefined ? (
+            <span id="product-quantity-max-packs-hint">
+              Máximo de packs disponibles: {maxPacks}
+            </span>
+          ) : undefined
+        }
+        describedBy={
+          productType === "package" && maxPacks !== undefined
+            ? "product-quantity-max-packs-hint"
+            : undefined
+        }
         placeholder="0"
       />
 

--- a/app/frontend/src/components/provider/products/form/product-form.validation.ts
+++ b/app/frontend/src/components/provider/products/form/product-form.validation.ts
@@ -20,6 +20,7 @@ type ProductFormValidationInput = {
   branchId: string;
   productType: ProductType;
   packageItems: Array<{ productId: number; quantity: number }>;
+  maxPacks?: number;
 };
 
 export function validateProductForm(
@@ -71,6 +72,15 @@ export function validateProductForm(
     input.packageItems.some((item) => !Number.isInteger(item.quantity) || item.quantity < 1)
   ) {
     nextErrors.packageItems = "Cada item del pack debe tener una cantidad valida mayor o igual a 1.";
+  }
+
+  if (
+    input.productType === "package" &&
+    input.maxPacks !== undefined &&
+    parsedQuantityAvailable !== null &&
+    parsedQuantityAvailable > input.maxPacks
+  ) {
+    nextErrors.quantityAvailable = `La cantidad de paquetes no puede superar el máximo disponible (${input.maxPacks}) según el stock de los productos seleccionados.`;
   }
 
   return nextErrors;

--- a/app/frontend/src/components/provider/products/form/product-pack-items-selector.tsx
+++ b/app/frontend/src/components/provider/products/form/product-pack-items-selector.tsx
@@ -5,6 +5,7 @@ interface PackItemOption {
   title: string;
   originalPrice: number;
   quantityAvailable: number;
+  availableForPackaging: number;
 }
 
 interface ProductPackItemsSelectorProps {
@@ -62,6 +63,7 @@ export function ProductPackItemsSelector({
                   <span className="block text-[#1A1A1A]">{option.title}</span>
                   <span className="block text-[#6A6A6A]">
                     {formatCurrency(option.originalPrice)} · Disponible: {option.quantityAvailable}
+                    {" "}· Disponible para empacar: {option.availableForPackaging}
                   </span>
                 </span>
 
@@ -74,7 +76,7 @@ export function ProductPackItemsSelector({
                       id={`pack-item-qty-${option.id}`}
                       type="number"
                       min={1}
-                      max={option.quantityAvailable}
+                      max={option.availableForPackaging}
                       value={selectedQuantity}
                       disabled={disabled}
                       onChange={(event) => {

--- a/app/frontend/src/components/provider/products/form/use-product-form-state.ts
+++ b/app/frontend/src/components/provider/products/form/use-product-form-state.ts
@@ -17,6 +17,23 @@ import {
   validateProductForm,
 } from "./product-form.validation";
 
+const MAX_PACKS_ERROR_PATTERN =
+  /^The requested quantity_available \((\d+)\) exceeds the maximum packs available given current stock \(max: (\d+)\)\.$/;
+
+function translateQuantityAvailableError(message?: string): string | undefined {
+  if (!message) {
+    return message;
+  }
+
+  const match = message.match(MAX_PACKS_ERROR_PATTERN);
+  if (!match) {
+    return message;
+  }
+
+  const [, requested, max] = match;
+  return `La cantidad de paquetes solicitada (${requested}) supera el máximo disponible según el stock actual (máx: ${max}).`;
+}
+
 type ProductFormInitialData = {
   commerceId?: number;
   quantityTotal?: number;
@@ -34,7 +51,12 @@ type ProductFormInitialData = {
 type UseProductFormStateParams = {
   initialData?: ProductFormInitialData | null;
   fieldErrors: ProviderProductFormFieldErrors;
-  packItemOptions: Array<{ id: number; originalPrice: number, quantityAvailable: number }>;
+  packItemOptions: Array<{
+    id: number;
+    originalPrice: number;
+    quantityAvailable: number;
+    availableForPackaging: number;
+  }>;
   onSubmit: (input: ProviderProductFormInput) => Promise<void>;
 };
 
@@ -73,7 +95,8 @@ export function useProductFormState({
       discountedPrice:
         localErrors.discountedPrice ?? fieldErrors["product.discounted_price"],
       quantityAvailable:
-        localErrors.quantityAvailable ?? fieldErrors["product.quantity_available"],
+        localErrors.quantityAvailable ??
+        translateQuantityAvailableError(fieldErrors["product.quantity_available"]),
       branchId:
         localErrors.branchId ?? fieldErrors["commerce_branch_ids.0"] ?? fieldErrors["commerce_branches.0"],
       packageItems: localErrors.packageItems ?? packageItemsFieldError,
@@ -101,6 +124,39 @@ export function useProductFormState({
         : ""
       : originalPrice;
 
+  // En modo edición, available_for_packaging ya descuenta el compromiso actual de
+  // este mismo pack sobre cada producto; lo sumamos de vuelta para reflejar cuánto
+  // queda disponible si este pack ajusta su cantidad.
+  const effectiveAvailableForPackaging = useMemo(() => {
+    const originalQuantities = new Map(
+      (initialData?.packageItems ?? []).map((item) => [item.productId, item.quantity])
+    );
+    const currentPackQuantity = initialData?.quantityAvailable ?? 0;
+
+    const result = new Map<number, number>();
+    packItemOptions.forEach((option) => {
+      const originalPivotQuantity = originalQuantities.get(option.id) ?? 0;
+      result.set(
+        option.id,
+        option.availableForPackaging + originalPivotQuantity * currentPackQuantity
+      );
+    });
+
+    return result;
+  }, [packItemOptions, initialData]);
+
+  const maxPacks = useMemo(() => {
+    if (productType !== "package" || packageItems.length === 0) {
+      return undefined;
+    }
+
+    return packageItems.reduce((min, item) => {
+      const available = effectiveAvailableForPackaging.get(item.productId) ?? 0;
+      const possiblePacks = item.quantity > 0 ? Math.floor(available / item.quantity) : 0;
+      return Math.min(min, possiblePacks);
+    }, Number.MAX_SAFE_INTEGER);
+  }, [productType, packageItems, effectiveAvailableForPackaging]);
+
   const validate = (): boolean => {
     const nextErrors = validateProductForm({
       title,
@@ -111,6 +167,7 @@ export function useProductFormState({
       branchId,
       productType,
       packageItems,
+      maxPacks,
     });
 
     setLocalErrors(nextErrors);
@@ -144,7 +201,10 @@ export function useProductFormState({
 
   const handlePackItemQuantityChange = (productId: number, quantity: number) => {
     const option = packItemOptions.find((item) => item.id === productId);
-    const maxQuantity = option?.quantityAvailable ?? Number.MAX_SAFE_INTEGER;
+    const maxQuantity =
+      effectiveAvailableForPackaging.get(productId) ??
+      option?.quantityAvailable ??
+      Number.MAX_SAFE_INTEGER;
     const normalizedQuantity = Math.max(1, Math.min(quantity, maxQuantity));
 
     setPackageItems((previous) => {
@@ -216,6 +276,7 @@ export function useProductFormState({
     branchId,
     setBranchId,
     packageItems,
+    maxPacks,
     mergedErrors,
     handleTogglePackItem,
     handlePackItemQuantityChange,

--- a/app/frontend/src/components/provider/ui/input-field.tsx
+++ b/app/frontend/src/components/provider/ui/input-field.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from "react";
-import type { ComponentPropsWithoutRef } from "react";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
 import { cn } from "./utils";
 import { FormField } from "./form-field";
 import { Input } from "./input";
@@ -9,7 +9,8 @@ type InputFieldProps = {
   label: string;
   required?: boolean;
   error?: string;
-  helperText?: string;
+  helperText?: ReactNode;
+  describedBy?: string;
   containerClassName?: string;
   inputClassName?: string;
 } & ComponentPropsWithoutRef<"input">;
@@ -21,12 +22,19 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function
     required = false,
     error,
     helperText,
+    describedBy,
     containerClassName,
     inputClassName,
     ...inputProps
   },
   ref
 ) {
+  const ariaDescribedBy = error
+    ? describedBy
+      ? `${id}-error ${describedBy}`
+      : `${id}-error`
+    : describedBy;
+
   return (
     <FormField
       id={id}
@@ -40,7 +48,7 @@ export const InputField = forwardRef<HTMLInputElement, InputFieldProps>(function
         ref={ref}
         id={id}
         aria-invalid={Boolean(error)}
-        aria-describedby={error ? `${id}-error` : undefined}
+        aria-describedby={ariaDescribedBy}
         className={cn(
           "h-[50px] rounded-[14px] border border-[#E0E0E0] px-4 text-[#1A1A1A] bg-white focus-visible:ring-2 focus-visible:ring-[#4B236A]/30",
           "disabled:opacity-60 disabled:cursor-not-allowed",

--- a/app/frontend/src/lib/api/products.ts
+++ b/app/frontend/src/lib/api/products.ts
@@ -157,6 +157,10 @@ function normalizeProduct(product: ProductFromAPI): ProductFromAPI {
         : toNumber(product.discounted_price),
     quantity_total: toInteger(product.quantity_total),
     quantity_available: toInteger(product.quantity_available),
+    available_for_packaging:
+      product.available_for_packaging === undefined
+        ? undefined
+        : toInteger(product.available_for_packaging),
     photos: product.photos ?? [],
   };
 }

--- a/app/frontend/src/types/products.ts
+++ b/app/frontend/src/types/products.ts
@@ -39,6 +39,7 @@ export interface ProductFromAPI {
   discounted_price: number | null;
   quantity_total: number;
   quantity_available: number;
+  available_for_packaging?: number;
   expires_at: string | null;
   photos?: ProductPhotoFromAPI[];
   status: string;


### PR DESCRIPTION
Agrega PackageAvailabilityCalculator para calcular available_for_packaging por producto y max_packs por pack, considerando el stock comprometido por otros packs y reservas activas de ordenes. Valida en StoreProductRequest y UpdateProductRequest que quantity_available de un pack no exceda la capacidad real de stock, y que package_items solo referencie productos single. Expone available_for_packaging en ProductResource y agrega UX en el formulario (hint de maximo de packs, validacion bloqueante, traduccion de errores). Incluye tests unitarios y de feature (35+7), con verificacion de ausencia de N+1.

Issue: SCRUM-276