### PR TITLE
fix(docs): reemplazo atómico de documentos duplicados en validación d…

### DIFF
--- a/app/backend/app/Services/DocumentUploadService.php
+++ b/app/backend/app/Services/DocumentUploadService.php
@@ -3,8 +3,10 @@
 namespace App\Services;
 
 use App\Constants\Constant;
+use App\Models\CommerceDocument;
 use Aws\S3\S3Client;
 use Exception;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 class DocumentUploadService
@@ -116,6 +118,11 @@ class DocumentUploadService
 
     /**
      * Actualizar documento tras confirmación
+     *
+     * Si el modelo es un CommerceDocument con document_type, sustituye
+     * (soft-delete) al documento confirmado previo del mismo
+     * (commerce_id, document_type) y encadena el versionado, para que
+     * solo quede un documento activo por tipo.
      */
     public function confirmUpload($model, array $data): bool
     {
@@ -130,14 +137,39 @@ class DocumentUploadService
             }
         }
 
-        return $model->update([
-            'upload_status' => Constant::UPLOAD_STATUS_CONFIRMED,
-            's3_etag' => $data['s3_metadata']['etag'],
-            's3_object_size' => $data['s3_metadata']['object_size'],
-            's3_last_modified' => $lastModified,
-            'expires_at' => null,
-            'failed_attempts' => 0,
-        ]);
+        return DB::transaction(function () use ($model, $data, $lastModified) {
+            $updateData = [
+                'upload_status' => Constant::UPLOAD_STATUS_CONFIRMED,
+                's3_etag' => $data['s3_metadata']['etag'],
+                's3_object_size' => $data['s3_metadata']['object_size'],
+                's3_last_modified' => $lastModified,
+                'expires_at' => null,
+                'failed_attempts' => 0,
+            ];
+
+            $previousDocument = null;
+
+            if ($model instanceof CommerceDocument && $model->document_type) {
+                $previousDocument = CommerceDocument::where('commerce_id', $model->commerce_id)
+                    ->where('document_type', $model->document_type)
+                    ->where('upload_status', Constant::UPLOAD_STATUS_CONFIRMED)
+                    ->where('id', '!=', $model->id)
+                    ->lockForUpdate()
+                    ->first();
+
+                if ($previousDocument) {
+                    $updateData['replacement_of_id'] = $previousDocument->id;
+                    $updateData['version_of_id'] = $previousDocument->version_of_id ?? $previousDocument->id;
+                    $updateData['version_number'] = $previousDocument->version_number + 1;
+                }
+            }
+
+            $result = $model->update($updateData);
+
+            $previousDocument?->delete();
+
+            return $result;
+        });
     }
 
     /**

--- a/app/backend/tests/Feature/Api/V1/DocumentUploadControllerTest.php
+++ b/app/backend/tests/Feature/Api/V1/DocumentUploadControllerTest.php
@@ -189,4 +189,249 @@ class DocumentUploadControllerTest extends TestCase
                 'message' => 'The presigned URL has expired.',
             ]);
     }
+
+    /**
+     * @return void
+     */
+    public function test_confirm_supersedes_previous_document_of_same_type()
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('admin.providers.upload_documents');
+        $this->actingAs($user);
+
+        $commerce = Commerce::factory()->create();
+
+        $previousDocument = CommerceDocument::factory()->create([
+            'commerce_id' => $commerce->id,
+            'document_type' => 'CAMARA_COMERCIO',
+            'upload_status' => 'confirmed',
+            'version_number' => 1,
+        ]);
+
+        $newDocument = CommerceDocument::factory()->create([
+            'commerce_id' => $commerce->id,
+            'document_type' => 'CAMARA_COMERCIO',
+            'upload_token' => Str::uuid()->toString(),
+            'expires_at' => now()->addHour(),
+            'upload_status' => 'pending',
+        ]);
+
+        $payload = [
+            'upload_token' => $newDocument->upload_token,
+            's3_metadata' => [
+                'etag' => 'etag-new',
+                'object_size' => 2048,
+                'last_modified' => now()->toIso8601String(),
+            ],
+        ];
+
+        $response = $this->patchJson('/api/v1/documents/confirm', $payload);
+
+        $response->assertStatus(200);
+
+        $this->assertSoftDeleted('commerce_documents', ['id' => $previousDocument->id]);
+
+        $newDocument->refresh();
+        $this->assertSame('confirmed', $newDocument->upload_status);
+        $this->assertSame($previousDocument->id, $newDocument->replacement_of_id);
+        $this->assertSame($previousDocument->id, $newDocument->version_of_id);
+        $this->assertSame(2, $newDocument->version_number);
+    }
+
+    /**
+     * @return void
+     */
+    public function test_confirmed_documents_list_excludes_superseded_document()
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('admin.providers.upload_documents');
+        $this->actingAs($user);
+
+        $commerce = Commerce::factory()->create();
+
+        CommerceDocument::factory()->create([
+            'commerce_id' => $commerce->id,
+            'document_type' => 'CAMARA_COMERCIO',
+            'upload_status' => 'confirmed',
+            'version_number' => 1,
+        ]);
+
+        $newDocument = CommerceDocument::factory()->create([
+            'commerce_id' => $commerce->id,
+            'document_type' => 'CAMARA_COMERCIO',
+            'upload_token' => Str::uuid()->toString(),
+            'expires_at' => now()->addHour(),
+            'upload_status' => 'pending',
+        ]);
+
+        $payload = [
+            'upload_token' => $newDocument->upload_token,
+            's3_metadata' => [
+                'etag' => 'etag-new',
+                'object_size' => 2048,
+                'last_modified' => now()->toIso8601String(),
+            ],
+        ];
+
+        $this->patchJson('/api/v1/documents/confirm', $payload)->assertStatus(200);
+
+        $confirmedDocuments = $commerce->getConfirmedCommerceDocuments();
+
+        $this->assertCount(1, $confirmedDocuments);
+        $this->assertSame($newDocument->id, $confirmedDocuments->first()->id);
+    }
+
+    /**
+     * @return void
+     */
+    public function test_confirm_does_not_affect_document_of_different_type()
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('admin.providers.upload_documents');
+        $this->actingAs($user);
+
+        $commerce = Commerce::factory()->create();
+
+        $existingRutDocument = CommerceDocument::factory()->create([
+            'commerce_id' => $commerce->id,
+            'document_type' => 'RUT',
+            'upload_status' => 'confirmed',
+            'version_number' => 1,
+        ]);
+
+        $newDocument = CommerceDocument::factory()->create([
+            'commerce_id' => $commerce->id,
+            'document_type' => 'CAMARA_COMERCIO',
+            'upload_token' => Str::uuid()->toString(),
+            'expires_at' => now()->addHour(),
+            'upload_status' => 'pending',
+            'version_number' => 1,
+        ]);
+
+        $payload = [
+            'upload_token' => $newDocument->upload_token,
+            's3_metadata' => [
+                'etag' => 'etag-new',
+                'object_size' => 2048,
+                'last_modified' => now()->toIso8601String(),
+            ],
+        ];
+
+        $this->patchJson('/api/v1/documents/confirm', $payload)->assertStatus(200);
+
+        $existingRutDocument->refresh();
+        $this->assertNull($existingRutDocument->deleted_at);
+        $this->assertSame(1, $existingRutDocument->version_number);
+
+        $newDocument->refresh();
+        $this->assertNull($newDocument->replacement_of_id);
+        $this->assertSame(1, $newDocument->version_number);
+    }
+
+    /**
+     * @return void
+     */
+    public function test_confirm_chains_three_versions_of_the_same_document()
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('admin.providers.upload_documents');
+        $this->actingAs($user);
+
+        $commerce = Commerce::factory()->create();
+
+        $v1 = CommerceDocument::factory()->create([
+            'commerce_id' => $commerce->id,
+            'document_type' => 'ID_CARD',
+            'upload_status' => 'confirmed',
+            'version_number' => 1,
+        ]);
+
+        $v2 = CommerceDocument::factory()->create([
+            'commerce_id' => $commerce->id,
+            'document_type' => 'ID_CARD',
+            'upload_token' => Str::uuid()->toString(),
+            'expires_at' => now()->addHour(),
+            'upload_status' => 'pending',
+        ]);
+
+        $this->patchJson('/api/v1/documents/confirm', [
+            'upload_token' => $v2->upload_token,
+            's3_metadata' => [
+                'etag' => 'etag-v2',
+                'object_size' => 2048,
+                'last_modified' => now()->toIso8601String(),
+            ],
+        ])->assertStatus(200);
+
+        $v3 = CommerceDocument::factory()->create([
+            'commerce_id' => $commerce->id,
+            'document_type' => 'ID_CARD',
+            'upload_token' => Str::uuid()->toString(),
+            'expires_at' => now()->addHour(),
+            'upload_status' => 'pending',
+        ]);
+
+        $this->patchJson('/api/v1/documents/confirm', [
+            'upload_token' => $v3->upload_token,
+            's3_metadata' => [
+                'etag' => 'etag-v3',
+                'object_size' => 2048,
+                'last_modified' => now()->toIso8601String(),
+            ],
+        ])->assertStatus(200);
+
+        $this->assertSoftDeleted('commerce_documents', ['id' => $v1->id]);
+        $this->assertSoftDeleted('commerce_documents', ['id' => $v2->id]);
+
+        $v2->refresh();
+        $v3->refresh();
+
+        $this->assertSame($v1->id, $v2->replacement_of_id);
+        $this->assertSame($v1->id, $v2->version_of_id);
+        $this->assertSame(2, $v2->version_number);
+
+        $this->assertSame($v2->id, $v3->replacement_of_id);
+        $this->assertSame($v1->id, $v3->version_of_id);
+        $this->assertSame(3, $v3->version_number);
+
+        $confirmedDocuments = $commerce->getConfirmedCommerceDocuments();
+        $this->assertCount(1, $confirmedDocuments);
+        $this->assertSame($v3->id, $confirmedDocuments->first()->id);
+    }
+
+    /**
+     * @return void
+     */
+    public function test_confirm_first_document_of_its_type_does_not_supersede_anything()
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('admin.providers.upload_documents');
+        $this->actingAs($user);
+
+        $document = CommerceDocument::factory()->create([
+            'document_type' => 'CAMARA_COMERCIO',
+            'upload_token' => Str::uuid()->toString(),
+            'expires_at' => now()->addHour(),
+            'upload_status' => 'pending',
+            'version_number' => 1,
+        ]);
+
+        $payload = [
+            'upload_token' => $document->upload_token,
+            's3_metadata' => [
+                'etag' => 'etag12345',
+                'object_size' => 2048,
+                'last_modified' => now()->toIso8601String(),
+            ],
+        ];
+
+        $response = $this->patchJson('/api/v1/documents/confirm', $payload);
+
+        $response->assertStatus(200);
+
+        $document->refresh();
+        $this->assertSame('confirmed', $document->upload_status);
+        $this->assertNull($document->replacement_of_id);
+        $this->assertSame(1, $document->version_number);
+    }
 }


### PR DESCRIPTION
Implementa supersede automático al confirmar un documento: si existe un documento confirmado previo del mismo (commerce_id, document_type), lo soft-deletea y encadena el versionado (replacement_of_id, version_of_id, version_number). Corrige SCRUM-294 (proveedor re-subida duplica), SCRUM-285 (admin ve documentos duplicados), SCRUM-282 (campo duplicado).

- DocumentUploadService::confirmUpload envuelve en DB::transaction
- Búsqueda con lockForUpdate para evitar condición de carrera
- Guard instanceof CommerceDocument para no afectar CommerceBranchPhoto/ProductPhoto
- 5 tests nuevos: supersede, no-cruce entre tipos, cadena de versiones, regresión
- Suite completa: 328 passed (1189 assertions), sin regresiones