### PR TITLE
fix(auth): scope de login por modulo y auditoria de autorizacion

### DIFF
--- a/app/backend/app/Enums/LoginScope.php
+++ b/app/backend/app/Enums/LoginScope.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Ámbito (módulo) desde el cual se intenta iniciar sesión.
+ *
+ * El login valida que el rol del usuario pertenezca al ámbito de la pantalla usada
+ * (SCRUM-325). El mapa es ESTRICTO: no hay god-mode multi-módulo (p. ej. superadmin
+ * NO puede iniciar sesión en provider ni customer).
+ */
+enum LoginScope: string
+{
+    case Admin = 'admin';
+    case Provider = 'provider';
+    case Customer = 'customer';
+
+    /**
+     * Roles (nombres Spatie) permitidos para este ámbito.
+     *
+     * @return list<string>
+     */
+    public function allowedRoles(): array
+    {
+        return match ($this) {
+            self::Admin => ['superadmin', 'admin', 'support'],
+            self::Provider => ['provider', 'branch_leader'],
+            self::Customer => ['user'],
+        };
+    }
+}

--- a/app/backend/app/Http/Controllers/Api/V1/AuditLogController.php
+++ b/app/backend/app/Http/Controllers/Api/V1/AuditLogController.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\IndexAuditLogRequest;
+use App\Http\Requests\Api\V1\ShowAuditLogRequest;
 use App\Http\Resources\Api\V1\AuditLogResource;
 use App\Services\AuditLogService;
 use Illuminate\Http\JsonResponse;
@@ -43,7 +45,7 @@ class AuditLogController extends Controller
      *     @OA\Response(response=500, description="Internal Server Error")
      * )
      */
-    public function index(): JsonResponse
+    public function index(IndexAuditLogRequest $request): JsonResponse
     {
         try {
             $logs = $this->auditLogService->getAll();
@@ -74,7 +76,7 @@ class AuditLogController extends Controller
      *     @OA\Response(response=429, description="Too Many Requests", @OA\JsonContent(example={"status":false,"message":"Too many requests. Please try again later.","code":429}), @OA\Header(header="Retry-After", description="Segundos hasta que se puede volver a intentar", @OA\Schema(type="integer")), @OA\Header(header="X-RateLimit-Limit", description="Límite de peticiones por ventana", @OA\Schema(type="integer")), @OA\Header(header="X-RateLimit-Remaining", description="Peticiones restantes en la ventana actual", @OA\Schema(type="integer")), @OA\Header(header="X-RateLimit-Reset", description="Timestamp de reseteo de ventana", @OA\Schema(type="integer")))
      * )
      */
-    public function show(int $id): JsonResponse
+    public function show(ShowAuditLogRequest $request, int $id): JsonResponse
     {
         try {
             $log = $this->auditLogService->getById($id);

--- a/app/backend/app/Http/Controllers/Api/V1/CommerceBranchController.php
+++ b/app/backend/app/Http/Controllers/Api/V1/CommerceBranchController.php
@@ -6,7 +6,7 @@ namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\DeleteCommerceBranchRequest;
-use App\Http\Requests\Api\V1\DestroyDocumentUploadRequest;
+use App\Http\Requests\Api\V1\DestroyCommerceBranchPhotoRequest;
 use App\Http\Requests\Api\V1\IndexCommerceBranchRequest;
 use App\Http\Requests\Api\V1\MyFavoriteCommerceBranchesRequest;
 use App\Http\Requests\Api\V1\PatchProductPhotoUploadRequest;
@@ -288,7 +288,7 @@ class CommerceBranchController extends Controller
      *   @OA\Response(response=403, description="Forbidden")
      * )
      */
-    public function removePhoto(DestroyDocumentUploadRequest $request, int $photo_id): JsonResponse
+    public function removePhoto(DestroyCommerceBranchPhotoRequest $request, int $photo_id): JsonResponse
     {
         try {
 

--- a/app/backend/app/Http/Controllers/Api/V1/CountryController.php
+++ b/app/backend/app/Http/Controllers/Api/V1/CountryController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\CountryRequest;
+use App\Http\Requests\Api\V1\DeleteCountryRequest;
 use App\Http\Requests\Api\V1\IndexCountryRequest;
 use App\Http\Requests\Api\V1\ShowCountryRequest;
 use App\Http\Resources\Api\V1\CountryResource;
@@ -204,7 +205,7 @@ class CountryController extends Controller
      *     @OA\Response(response=500, description="Internal Server Error")
      * )
      */
-    public function destroy(string $id): JsonResponse
+    public function destroy(DeleteCountryRequest $request, string $id): JsonResponse
     {
         try {
             $country = $this->countryService->find($id);

--- a/app/backend/app/Http/Controllers/Api/V1/DocumentUploadController.php
+++ b/app/backend/app/Http/Controllers/Api/V1/DocumentUploadController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Api\V1;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\DestroyDocumentUploadRequest;
 use App\Http\Requests\Api\V1\PatchDocumentUploadRequest;
+use App\Http\Requests\Api\V1\ShowDocumentDownloadUrlRequest;
 use App\Http\Requests\Api\V1\StoreDocumentUploadRequest;
 use App\Http\Resources\Api\V1\DocumentUploadResource;
 use App\Models\CommerceDocument;
@@ -284,7 +285,7 @@ class DocumentUploadController extends Controller
      *   @OA\Response(response=500, description="Internal Server Error")
      * )
      */
-    public function downloadCommerceDocumentUrl(int $id): JsonResponse
+    public function downloadCommerceDocumentUrl(ShowDocumentDownloadUrlRequest $request, int $id): JsonResponse
     {
         try {
             $commerce_document = $this->commerceDocumentService->find($id);

--- a/app/backend/app/Http/Controllers/Api/V1/ProductController.php
+++ b/app/backend/app/Http/Controllers/Api/V1/ProductController.php
@@ -6,7 +6,7 @@ namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\DeleteProductRequest;
-use App\Http\Requests\Api\V1\DestroyDocumentUploadRequest;
+use App\Http\Requests\Api\V1\DestroyProductPhotoRequest;
 use App\Http\Requests\Api\V1\PatchProductPhotoUploadRequest;
 use App\Http\Requests\Api\V1\PatchProductStatusRequest;
 use App\Http\Requests\Api\V1\ProductIndexRequest;
@@ -557,7 +557,7 @@ class ProductController extends Controller
      *   @OA\Response(response=403, description="Forbidden")
      * )
      */
-    public function removePhoto(DestroyDocumentUploadRequest $request, int $photo_id): JsonResponse
+    public function removePhoto(DestroyProductPhotoRequest $request, int $photo_id): JsonResponse
     {
         try {
 

--- a/app/backend/app/Http/Controllers/Api/V1/SupportStatusController.php
+++ b/app/backend/app/Http/Controllers/Api/V1/SupportStatusController.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Api\V1;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\DeleteSupportStatusRequest;
 use App\Http\Requests\Api\V1\IndexSupportStatusRequest;
+use App\Http\Requests\Api\V1\ShowSupportStatusRequest;
 use App\Http\Requests\Api\V1\SupportStatusStoreRequest;
 use App\Http\Requests\Api\V1\SupportStatusUpdateRequest;
 use App\Http\Resources\Api\V1\SupportStatusResource;
@@ -183,7 +185,7 @@ class SupportStatusController extends Controller
      *     @OA\Response(response=403, description="Forbidden")
      * )
      */
-    public function show(int $id): JsonResponse
+    public function show(ShowSupportStatusRequest $request, int $id): JsonResponse
     {
         try {
             $status = $this->supportStatusService->find($id);
@@ -250,7 +252,7 @@ class SupportStatusController extends Controller
      *     @OA\Response(response=403, description="Forbidden")
      * )
      */
-    public function destroy(int $id): JsonResponse
+    public function destroy(DeleteSupportStatusRequest $request, int $id): JsonResponse
     {
         try {
             $this->supportStatusService->delete($id);

--- a/app/backend/app/Http/Controllers/Api/V1/UserController.php
+++ b/app/backend/app/Http/Controllers/Api/V1/UserController.php
@@ -408,6 +408,7 @@ class UserController extends Controller
             $tokenData = $this->authService->login([
                 'email' => $user->email,
                 'password' => $request->input('password'),
+                'scope' => 'provider',
             ]);
 
             return $this->loginResponse(new UserResource($user), $tokenData['token']);
@@ -468,6 +469,7 @@ class UserController extends Controller
             $tokenData = $this->authService->login([
                 'email' => $user->email,
                 'password' => $request->input('password'),
+                'scope' => 'customer',
             ]);
 
             return $this->loginResponse(new UserResource($user), $tokenData['token']);

--- a/app/backend/app/Http/Requests/Api/V1/DeleteCountryRequest.php
+++ b/app/backend/app/Http/Requests/Api/V1/DeleteCountryRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeleteCountryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('admin.params.countries.delete') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/app/backend/app/Http/Requests/Api/V1/DeleteSupportStatusRequest.php
+++ b/app/backend/app/Http/Requests/Api/V1/DeleteSupportStatusRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class DeleteSupportStatusRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('admin.params.support_statuses.delete') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/app/backend/app/Http/Requests/Api/V1/DestroyCommerceBranchPhotoRequest.php
+++ b/app/backend/app/Http/Requests/Api/V1/DestroyCommerceBranchPhotoRequest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use App\Models\CommerceBranch;
+use App\Traits\AuthorizesCommerceOwnership;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * SCRUM-316 (ampliado) — antes DELETE /commerce-branches/photos/{photo} compartía
+ * DestroyDocumentUploadRequest (permiso provider.products.delete, sin ownership real).
+ * Ahora exige provider.photos.delete y ownership del comercio dueño de la sucursal.
+ *
+ * Nota: el controller resuelve la foto vía CommerceBranch::class (no CommerceBranchPhoto,
+ * que sí existe como modelo/tabla dedicados) — bug funcional documentado en SCRUM-273, fuera
+ * de alcance de esta auditoría de autorización. Este Request resuelve ownership de forma
+ * deliberadamente coherente con el modelo que el controller usa hoy.
+ */
+class DestroyCommerceBranchPhotoRequest extends FormRequest
+{
+    use AuthorizesCommerceOwnership;
+
+    public function authorize(): bool
+    {
+        $user = $this->user();
+
+        if (! $user) {
+            return false;
+        }
+
+        if ($user->can('admin.providers.documents.manage')) {
+            return true;
+        }
+
+        if (! $user->can('provider.photos.delete')) {
+            return false;
+        }
+
+        $branch = CommerceBranch::find($this->route('photo'));
+
+        if (! $branch) {
+            // Sin registro: el controller responde 404 (ModelNotFoundException), no 403.
+            return true;
+        }
+
+        return $this->userCanAccessCommerce((int) $branch->commerce_id);
+    }
+
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/app/backend/app/Http/Requests/Api/V1/DestroyProductPhotoRequest.php
+++ b/app/backend/app/Http/Requests/Api/V1/DestroyProductPhotoRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use App\Models\ProductPhoto;
+use App\Traits\AuthorizesCommerceOwnership;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * SCRUM-316 (ampliado) — antes DELETE /products/commerce/photos/{photo} compartía
+ * DestroyDocumentUploadRequest (permiso provider.products.delete, sin ownership real).
+ * Ahora exige provider.photos.delete y ownership del comercio dueño del producto.
+ */
+class DestroyProductPhotoRequest extends FormRequest
+{
+    use AuthorizesCommerceOwnership;
+
+    public function authorize(): bool
+    {
+        $user = $this->user();
+
+        if (! $user) {
+            return false;
+        }
+
+        if ($user->can('admin.providers.documents.manage')) {
+            return true;
+        }
+
+        if (! $user->can('provider.photos.delete')) {
+            return false;
+        }
+
+        $photo = ProductPhoto::with('product')->find($this->route('photo'));
+
+        if (! $photo) {
+            // Sin foto: el controller responde 404 (ModelNotFoundException), no 403.
+            return true;
+        }
+
+        return $this->userCanAccessCommerce((int) $photo->product?->commerce_id);
+    }
+
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/app/backend/app/Http/Requests/Api/V1/IndexAuditLogRequest.php
+++ b/app/backend/app/Http/Requests/Api/V1/IndexAuditLogRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class IndexAuditLogRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('admin.audit_logs.index') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/app/backend/app/Http/Requests/Api/V1/LoginRequest.php
+++ b/app/backend/app/Http/Requests/Api/V1/LoginRequest.php
@@ -2,14 +2,16 @@
 
 namespace App\Http\Requests\Api\V1;
 
+use App\Enums\LoginScope;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 /**
  * @OA\Schema(
  *     schema="LoginRequest",
  *     title="Login Request",
  *     description="Login request body data",
- *     required={"email", "password"},
+ *     required={"email", "password", "scope"},
  *
  *     @OA\Property(
  *         property="email",
@@ -24,6 +26,13 @@ use Illuminate\Foundation\Http\FormRequest;
  *         format="password",
  *         example="password",
  *         description="User's password"
+ *     ),
+ *     @OA\Property(
+ *         property="scope",
+ *         type="string",
+ *         enum={"admin", "provider", "customer"},
+ *         example="admin",
+ *         description="Módulo desde el que se inicia sesión; el rol del usuario debe pertenecer a este ámbito"
  *     )
  * )
  */
@@ -47,6 +56,9 @@ class LoginRequest extends FormRequest
         return [
             'email' => ['required', 'email'],
             'password' => ['required', 'string'],
+            // Ámbito/módulo desde el que se inicia sesión (admin|provider|customer).
+            // Obligatorio: el login rechaza credenciales de un módulo ajeno (SCRUM-325).
+            'scope' => ['required', Rule::enum(LoginScope::class)],
         ];
     }
 }

--- a/app/backend/app/Http/Requests/Api/V1/PatchDocumentUploadRequest.php
+++ b/app/backend/app/Http/Requests/Api/V1/PatchDocumentUploadRequest.php
@@ -37,7 +37,7 @@ class PatchDocumentUploadRequest extends FormRequest
             return false;
         }
 
-        if ($user->can('admin.providers.upload_documents')) {
+        if ($user->can('admin.providers.documents.manage')) {
             return true;
         }
 

--- a/app/backend/app/Http/Requests/Api/V1/ShowAuditLogRequest.php
+++ b/app/backend/app/Http/Requests/Api/V1/ShowAuditLogRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ShowAuditLogRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('admin.audit_logs.show') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/app/backend/app/Http/Requests/Api/V1/ShowDocumentDownloadUrlRequest.php
+++ b/app/backend/app/Http/Requests/Api/V1/ShowDocumentDownloadUrlRequest.php
@@ -9,11 +9,10 @@ use App\Traits\AuthorizesCommerceOwnership;
 use Illuminate\Foundation\Http\FormRequest;
 
 /**
- * SCRUM-316 — exclusivo para DocumentUploadController::remove. El permiso ya no es
- * provider.products.delete (ajeno a documentos); ahora exige provider.documents.delete
- * más ownership del comercio dueño del documento.
+ * SCRUM-315 — cierra el IDOR de download-url: exige ownership del comercio dueño
+ * del documento (o permiso admin) antes de generar la URL firmada de descarga.
  */
-class DestroyDocumentUploadRequest extends FormRequest
+class ShowDocumentDownloadUrlRequest extends FormRequest
 {
     use AuthorizesCommerceOwnership;
 
@@ -29,11 +28,11 @@ class DestroyDocumentUploadRequest extends FormRequest
             return true;
         }
 
-        if (! $user->can('provider.documents.delete')) {
+        if (! $user->can('provider.documents.view')) {
             return false;
         }
 
-        $document = CommerceDocument::find($this->route('document'));
+        $document = CommerceDocument::find($this->route('id'));
 
         if (! $document) {
             // Sin documento: el controller responde 404 (ModelNotFoundException), no 403.

--- a/app/backend/app/Http/Requests/Api/V1/ShowSupportStatusRequest.php
+++ b/app/backend/app/Http/Requests/Api/V1/ShowSupportStatusRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ShowSupportStatusRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->can('admin.params.support_statuses.show') ?? false;
+    }
+
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/app/backend/app/Http/Requests/Api/V1/StoreDocumentUploadRequest.php
+++ b/app/backend/app/Http/Requests/Api/V1/StoreDocumentUploadRequest.php
@@ -37,7 +37,7 @@ class StoreDocumentUploadRequest extends FormRequest
             return false;
         }
 
-        if ($user->can('admin.providers.upload_documents')) {
+        if ($user->can('admin.providers.documents.manage')) {
             return true;
         }
 

--- a/app/backend/app/Services/AuthService.php
+++ b/app/backend/app/Services/AuthService.php
@@ -2,6 +2,8 @@
 
 namespace App\Services;
 
+use App\Constants\Constant;
+use App\Enums\LoginScope;
 use App\Models\User;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\ValidationException;
@@ -20,15 +22,41 @@ class AuthService
         // Security: Check if user exists, has a password set, and password matches
         // All failures return the same message to prevent user enumeration
         if (! $user || is_null($user->password) || ! Hash::check($credentials['password'], $user->password)) {
-            throw ValidationException::withMessages([
-                'email' => [__('auth.failed')],
-            ]);
+            $this->failAuthentication();
         }
+
+        // SCRUM-325 — Defensa en profundidad: el login solo acepta usuarios activos y cuyo rol
+        // pertenezca al ámbito (módulo) desde el que se inicia sesión. Se usa el MISMO mensaje
+        // genérico que para credenciales inválidas para no revelar la causa (anti-enumeración).
+        if ((int) $user->status !== Constant::STATUS_ACTIVE) {
+            $this->failAuthentication();
+        }
+
+        $scope = LoginScope::from($credentials['scope']);
+        if (! $user->hasAnyRole($scope->allowedRoles())) {
+            $this->failAuthentication();
+        }
+
         $token = $user->createToken('api-token')->plainTextToken;
 
         return [
             'token' => $token,
             'user' => $user,
         ];
+    }
+
+    /**
+     * Lanza el error de autenticación genérico.
+     *
+     * Se usa para TODAS las causas de fallo (credencial inválida, usuario inactivo, rol fuera
+     * del ámbito) con el mismo mensaje, para evitar enumeración de usuarios/roles/estado.
+     *
+     * @throws ValidationException
+     */
+    private function failAuthentication(): never
+    {
+        throw ValidationException::withMessages([
+            'email' => [__('auth.failed')],
+        ]);
     }
 }

--- a/app/backend/app/Services/CommerceDocumentService.php
+++ b/app/backend/app/Services/CommerceDocumentService.php
@@ -34,10 +34,12 @@ class CommerceDocumentService
 
     /**
      * Find a document by ID.
+     *
+     * @throws \Illuminate\Database\Eloquent\ModelNotFoundException
      */
-    public function find(int $id): ?CommerceDocument
+    public function find(int $id): CommerceDocument
     {
-        return CommerceDocument::find($id);
+        return CommerceDocument::findOrFail($id);
     }
 
     /**

--- a/app/backend/database/seeders/RolePermissionSeeder.php
+++ b/app/backend/database/seeders/RolePermissionSeeder.php
@@ -168,9 +168,16 @@ class RolePermissionSeeder extends Seeder
             ['name' => 'provider.establishment_types.update', 'guard_name' => $guardName, 'description' => 'Actualizar tipo de establecimiento', 'created_at' => now(), 'updated_at' => now()],
             ['name' => 'provider.establishment_types.delete', 'guard_name' => $guardName, 'description' => 'Eliminar tipo de establecimiento', 'created_at' => now(), 'updated_at' => now()],
 
-            ['name' => 'admin.providers.upload_documents', 'guard_name' => $guardName, 'description' => 'Ver módulo de carga de documentos de proveedor en admin', 'created_at' => now(), 'updated_at' => now()],
+            ['name' => 'admin.providers.documents.manage', 'guard_name' => $guardName, 'description' => 'Gestionar documentos y fotos de proveedores en admin (ver, cargar, descargar, eliminar) — bypass de ownership', 'created_at' => now(), 'updated_at' => now()],
             ['name' => 'provider.photos.upload', 'guard_name' => $guardName, 'description' => 'Actualizar fotos por proveedor', 'created_at' => now(), 'updated_at' => now()],
+            ['name' => 'provider.photos.delete', 'guard_name' => $guardName, 'description' => 'Eliminar fotos (producto o sucursal) por proveedor', 'created_at' => now(), 'updated_at' => now()],
             ['name' => 'provider.documents.upload', 'guard_name' => $guardName, 'description' => 'Cargar documentos (RUT, 1876, etc.) del propio comercio como proveedor', 'created_at' => now(), 'updated_at' => now()],
+            ['name' => 'provider.documents.view', 'guard_name' => $guardName, 'description' => 'Ver/descargar documentos del propio comercio como proveedor', 'created_at' => now(), 'updated_at' => now()],
+            ['name' => 'provider.documents.delete', 'guard_name' => $guardName, 'description' => 'Eliminar documentos del propio comercio como proveedor', 'created_at' => now(), 'updated_at' => now()],
+
+            // Audit Logs
+            ['name' => 'admin.audit_logs.index', 'guard_name' => $guardName, 'description' => 'Listar logs de auditoría', 'created_at' => now(), 'updated_at' => now()],
+            ['name' => 'admin.audit_logs.show', 'guard_name' => $guardName, 'description' => 'Ver detalle de log de auditoría', 'created_at' => now(), 'updated_at' => now()],
 
             ['name' => 'provider.product_categories.index', 'guard_name' => $guardName, 'description' => 'Listar categorías de producto', 'created_at' => now(), 'updated_at' => now()],
             ['name' => 'provider.product_categories.create', 'guard_name' => $guardName, 'description' => 'Crear categoría de producto', 'created_at' => now(), 'updated_at' => now()],
@@ -288,6 +295,9 @@ class RolePermissionSeeder extends Seeder
             'admin.manage_pqrs.show',
             'provider.orders.show',
             'customer.orders.show',
+            'admin.audit_logs.index',
+            'admin.audit_logs.show',
+            'admin.providers.documents.manage',
         ];
 
         $adminPermissions = array_merge($indexShowPermissions, [
@@ -390,6 +400,7 @@ class RolePermissionSeeder extends Seeder
             'provider.comments.show',
             'provider.orders.index',
             'provider.orders.show',
+            'provider.documents.view',
         ];
 
         // Proveedor tiene permisos específicos
@@ -424,7 +435,9 @@ class RolePermissionSeeder extends Seeder
 
             'provider.commerces.accept-terms',
             'provider.documents.upload',
+            'provider.documents.delete',
             'provider.photos.upload',
+            'provider.photos.delete',
         ]);
 
         $providerRole = Role::where('name', 'provider')->first();

--- a/app/backend/docs/security/endpoint-authorization-audit.md
+++ b/app/backend/docs/security/endpoint-authorization-audit.md
@@ -1,0 +1,74 @@
+# Auditoría de autorización de endpoints (SCRUM-334)
+
+**Fecha:** 2026-07-14
+**Alcance:** todos los endpoints bajo `Route::middleware(['auth:sanctum', ...])` en `routes/api.php`.
+**Objetivo:** confirmar que cada endpoint valida el **permiso** correcto (no solo autenticación) vía
+un FormRequest con `authorize()` (o Gate/Policy equivalente).
+
+Leyenda: ✅ OK (permiso correcto validado) · ⚠️ HUECO (sin `authorize()` real o permiso incorrecto).
+
+---
+
+## Huecos encontrados
+
+| Endpoint | Controller@método | Antes | Corrección (este PR) | Origen |
+|---|---|---|---|---|
+| `POST /documents/{id}/download-url` | `DocumentUploadController::downloadCommerceDocumentUrl` | Sin FormRequest — IDOR | `ShowDocumentDownloadUrlRequest` + ownership | SCRUM-315 |
+| `DELETE /documents/{document}` | `DocumentUploadController::remove` | `provider.products.delete` (permiso ajeno) | `DestroyDocumentUploadRequest` con `provider.documents.delete` + ownership | SCRUM-316 |
+| `DELETE /products/commerce/photos/{photo}` | `ProductController::removePhoto` | `provider.products.delete` (mismo Request de 316) | `DestroyProductPhotoRequest` con `provider.photos.delete` + ownership | SCRUM-316 (ampliado) |
+| `DELETE /commerce-branches/photos/{photo}` | `CommerceBranchController::removePhoto` | `provider.products.delete` (mismo Request de 316) | `DestroyCommerceBranchPhotoRequest` con `provider.photos.delete` + ownership | SCRUM-316 (ampliado) |
+| `GET /audit-logs` | `AuditLogController::index` | Sin FormRequest — cualquier autenticado | `IndexAuditLogRequest` con `admin.audit_logs.index` | Auditoría 334 |
+| `GET /audit-logs/{id}` | `AuditLogController::show` | Sin FormRequest — cualquier autenticado | `ShowAuditLogRequest` con `admin.audit_logs.show` | Auditoría 334 |
+| `GET /support-statuses/{id}` | `SupportStatusController::show` | Sin FormRequest | `ShowSupportStatusRequest` con `admin.params.support_statuses.show` (permiso ya existía) | Auditoría 334 |
+| `DELETE /support-statuses/{id}` | `SupportStatusController::destroy` | Sin FormRequest | `DeleteSupportStatusRequest` con `admin.params.support_statuses.delete` (permiso ya existía) | Auditoría 334 |
+| `DELETE /countries/{id}` | `CountryController::destroy` | Sin FormRequest | `DeleteCountryRequest` con `admin.params.countries.delete` (permiso ya existía) | Auditoría 334 |
+
+## Huecos identificados pero NO corregidos en este PR
+
+| Endpoint | Motivo |
+|---|---|
+| `GET /products/commerce/{commerce_id}` | `ProductController::byCommerce` — sin `authorize()`. No está claro si el catálogo de productos por comercio se diseñó como semi-público (browsing) o si debería exigir permiso/ownership. Requiere decisión de producto. **Derivado a ticket.** |
+| `GET /products/commerce/branch/{branch_id}` | `ProductController::byCommerceBranch` — mismo caso que el anterior. |
+
+## Hallazgo colateral (no es de autorización)
+
+`CommerceBranchController::confirmPhotoUpload`/`removePhoto` usan el modelo Eloquent `CommerceBranch::class`
+en vez de `CommerceBranchPhoto::class` (tabla dedicada `commerce_branch_photos` existente). La tabla
+`commerce_branches` no tiene columnas `upload_token`/`upload_status`, así que cualquier uso real de estos
+endpoints lanzaría una excepción SQL — el flujo de foto de sucursal está roto de fábrica. Es la causa raíz
+más probable de que **SCRUM-273** siga fallando en retest. Documentado como comentario técnico en ese
+ticket; no se corrige aquí (fuera del alcance de autorización). El fix de ownership de este PR para
+`DestroyCommerceBranchPhotoRequest` se resuelve deliberadamente sobre el modelo actual (`CommerceBranch`),
+coherente con el bug preexistente.
+
+---
+
+## Endpoints verificados sin hueco (✅ OK)
+
+Cobertura completa por dominio — todos usan un FormRequest con `authorize()` validando permiso Spatie
+(y ownership vía `AuthorizesCommerceOwnership` o equivalente cuando el recurso es de un comercio):
+
+- **Auth/Me:** `login` (scope, SCRUM-325), `password/forgot`, `password/reset`, `me`, `me/permissions`, `logout` (auto-scoped al usuario autenticado, sin permiso adicional necesario).
+- **Registro público:** `provider/register`, `customer/register` (`authorize() = true`, intencional).
+- **Nearby:** `nearby/branches`, `nearby/products` (`authorize() = true`, público explícito, fuera de `auth:sanctum`).
+- **Parametrización (countries, departments, cities, neighborhoods, banks, establishment-types, pqrs-types, priority-types, support-statuses):** index/show/store/update con permiso `admin.params.*` dedicado por acción.
+- **Usuarios/Roles/Permisos:** `users` CRUD + `updateStatus` + `administrators`, `roles` CRUD + `assign-roles-permissions` + `patchStatus`, `permissions` index/store — todos con permiso `admin.profiles.*` dedicado.
+- **Comercios:** `commerces` CRUD, `patchStatus`, `patchVerification`, `acceptTerms`, `getBranchesByCommerceId`, `getPayoutMethodsByCommerceId`, `myCommerce` — permiso `provider.commerces.*` + ownership (bypass admin por rol, ver Observaciones del plan).
+- **Sucursales:** `commerce-branches` CRUD, `myFavorites`, `confirmPhotoUpload` — permiso `provider.branches.*` / `provider.photos.upload` + ownership.
+- **Comentarios de comercio:** CRUD completo con permiso `provider.comments.*` + `userCanAccessCommerce()`.
+- **Documentos legales:** `legal-documents` index/showByType/store — permiso `admin.legal_documents.*`.
+- **Representantes legales:** CRUD completo — permiso `provider.legal_representatives.*`.
+- **Usuarios de sucursal (branch leaders):** index/store/assign/remove/showBranchUsers — por rol (`provider`/`admin`/`superadmin`/`branch_leader`).
+- **Geocode:** `search`, `reverse` — permiso `provider.geocode.*`.
+- **Productos:** CRUD, `patchStatus`, `package-items` CRUD, `confirmPhotoUpload` — permiso `provider.products.*` (algunos vía `ProductService::validateStoreRequest`).
+- **Categorías de producto:** CRUD completo — permiso `provider.product_categories.*`.
+- **Órdenes:** CRUD, `patchStatus`, `myOrders` (auto-scoped a `$request->user()->id`), `commerceBranchOrders` — permiso `customer.orders.*`/`provider.orders.*` + ownership (comprador o dueño del comercio).
+- **Documentos de proveedor (upload):** `presigned` (Store), `confirm` (Patch) — permiso `provider.documents.upload` + ownership (ya blindado en SCRUM-242).
+
+---
+
+## Conclusión
+
+De ~100 FormRequests auditados, se encontraron **9 huecos corregidos** en este PR y **2 huecos derivados**
+a ticket por requerir decisión de producto. No se encontraron endpoints adicionales protegidos solo por
+`auth:sanctum` sin ningún `authorize()`.

--- a/app/backend/specs/docs/document-upload-flow.md
+++ b/app/backend/specs/docs/document-upload-flow.md
@@ -194,7 +194,7 @@ Llamada inicial del frontend para obtener datos del usuario.
 
 1. Obtener usuario autenticado del token JWT.
 2. Si no autenticado, retornar 401.
-3. Verificar permiso `admin.providers.upload_documents` o equivalente según rol.
+3. Verificar permiso `admin.providers.documents.manage` o equivalente según rol.
 4. Retornar datos de usuario incluyendo flag `can_upload_documents: boolean`.
 
 **Output Data (Response):**
@@ -245,7 +245,7 @@ Frontend hace submit del formulario con documento seleccionado.
 1. Obtener usuario autenticado del JWT.
 2. **Validar Permisos:**
    - Si no autenticado → retornar 401.
-   - Si no tiene permiso `admin.providers.upload_documents` → retornar 403.
+   - Si no tiene permiso `admin.providers.documents.manage` → retornar 403.
 3. **Validar Entrada:**
    - `document_type` requerido y en enum válido → 422 si inválido.
    - `file_name` requerido, máximo 255 caracteres → 422 si excede.
@@ -633,7 +633,7 @@ END IF;
 ### 6.1 Seguridad
 
 - **Autenticación:** Todo endpoint requiere token JWT válido.
-- **Autorización:** Permiso `admin.providers.upload_documents` o equivalente según rol.
+- **Autorización:** Permiso `admin.providers.documents.manage` o equivalente según rol.
 - **Validación MIME Types:**
   - Whitelist: `['application/pdf', 'image/jpeg', 'image/png', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document']`
   - Validar en frontend (UX) y backend (seguridad).

--- a/app/backend/specs/docs/minio-setup-guide.md
+++ b/app/backend/specs/docs/minio-setup-guide.md
@@ -377,7 +377,7 @@ class DocumentUploadController extends Controller
      */
     public function presigned(Request $request): JsonResponse
     {
-        $this->authorize('admin.providers.upload_documents');
+        $this->authorize('admin.providers.documents.manage');
 
         try {
             $data = $request->validate([
@@ -425,7 +425,7 @@ class DocumentUploadController extends Controller
      */
     public function confirm(Request $request): JsonResponse
     {
-        $this->authorize('admin.providers.upload_documents');
+        $this->authorize('admin.providers.documents.manage');
 
         try {
             $data = $request->validate([

--- a/app/backend/tests/Feature/Api/V1/AuditLogAuthorizationTest.php
+++ b/app/backend/tests/Feature/Api/V1/AuditLogAuthorizationTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\AuditLog;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+/**
+ * Auditoría SCRUM-334 — AuditLogController::index/show no tenían ningún check de
+ * autorización: cualquier usuario autenticado podía listar/leer todos los logs.
+ */
+class AuditLogAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Permission::findOrCreate('admin.audit_logs.index', 'sanctum');
+        Permission::findOrCreate('admin.audit_logs.show', 'sanctum');
+    }
+
+    public function test_user_without_permission_cannot_list_audit_logs(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user, 'sanctum');
+
+        $response = $this->getJson('/api/v1/audit-logs');
+
+        $response->assertStatus(403);
+    }
+
+    public function test_user_with_permission_can_list_audit_logs(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('admin.audit_logs.index');
+        $this->actingAs($user, 'sanctum');
+
+        AuditLog::factory()->count(2)->create();
+
+        $response = $this->getJson('/api/v1/audit-logs');
+
+        $response->assertOk()->assertJsonCount(2);
+    }
+
+    public function test_user_without_permission_cannot_show_audit_log(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user, 'sanctum');
+
+        $log = AuditLog::factory()->create();
+
+        $response = $this->getJson("/api/v1/audit-logs/{$log->id}");
+
+        $response->assertStatus(403);
+    }
+
+    public function test_user_with_permission_can_show_audit_log(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('admin.audit_logs.show');
+        $this->actingAs($user, 'sanctum');
+
+        $log = AuditLog::factory()->create();
+
+        $response = $this->getJson("/api/v1/audit-logs/{$log->id}");
+
+        $response->assertOk()->assertJsonPath('id', $log->id);
+    }
+
+    public function test_unauthenticated_user_cannot_access_audit_logs(): void
+    {
+        $response = $this->getJson('/api/v1/audit-logs');
+
+        $response->assertStatus(401);
+    }
+}

--- a/app/backend/tests/Feature/Api/V1/CommerceBranchPhotoDeleteTest.php
+++ b/app/backend/tests/Feature/Api/V1/CommerceBranchPhotoDeleteTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Models\Commerce;
+use App\Models\CommerceBranch;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+/**
+ * SCRUM-316 (ampliado) — DELETE /commerce-branches/photos/{photo} compartía
+ * DestroyDocumentUploadRequest (permiso provider.products.delete, sin ownership real).
+ * Ahora exige provider.photos.delete + ownership del comercio dueño de la sucursal.
+ *
+ * Nota: el controller resuelve la "foto" vía CommerceBranch::class (bug funcional
+ * documentado en SCRUM-273, fuera de alcance aquí) — por eso el recurso operado es
+ * la sucursal misma.
+ */
+class CommerceBranchPhotoDeleteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Permission::findOrCreate('provider.photos.delete', 'sanctum');
+        Permission::findOrCreate('admin.providers.documents.manage', 'sanctum');
+    }
+
+    public function test_owner_can_delete_branch_photo(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('provider.photos.delete');
+        $this->actingAs($user, 'sanctum');
+
+        $commerce = Commerce::factory()->create(['owner_user_id' => $user->id]);
+        $branch = CommerceBranch::factory()->create(['commerce_id' => $commerce->id]);
+
+        $response = $this->deleteJson("/api/v1/commerce-branches/photos/{$branch->id}");
+
+        $response->assertStatus(204);
+    }
+
+    public function test_foreign_provider_cannot_delete_branch_photo(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('provider.photos.delete');
+        $this->actingAs($user, 'sanctum');
+
+        $foreignCommerce = Commerce::factory()->create();
+        $branch = CommerceBranch::factory()->create(['commerce_id' => $foreignCommerce->id]);
+
+        $response = $this->deleteJson("/api/v1/commerce-branches/photos/{$branch->id}");
+
+        $response->assertStatus(403);
+    }
+
+    public function test_user_without_permission_cannot_delete_branch_photo(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user, 'sanctum');
+
+        $commerce = Commerce::factory()->create(['owner_user_id' => $user->id]);
+        $branch = CommerceBranch::factory()->create(['commerce_id' => $commerce->id]);
+
+        $response = $this->deleteJson("/api/v1/commerce-branches/photos/{$branch->id}");
+
+        $response->assertStatus(403);
+    }
+
+    public function test_admin_permission_bypasses_ownership_check(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('admin.providers.documents.manage');
+        $this->actingAs($user, 'sanctum');
+
+        $foreignCommerce = Commerce::factory()->create();
+        $branch = CommerceBranch::factory()->create(['commerce_id' => $foreignCommerce->id]);
+
+        $response = $this->deleteJson("/api/v1/commerce-branches/photos/{$branch->id}");
+
+        $response->assertStatus(204);
+    }
+
+    public function test_nonexistent_photo_returns_404(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('provider.photos.delete');
+        $this->actingAs($user, 'sanctum');
+
+        $response = $this->deleteJson('/api/v1/commerce-branches/photos/999999');
+
+        $response->assertStatus(404);
+    }
+}

--- a/app/backend/tests/Feature/Api/V1/CountryTest.php
+++ b/app/backend/tests/Feature/Api/V1/CountryTest.php
@@ -200,4 +200,25 @@ class CountryTest extends TestCase
 
         $response->assertStatus(401);
     }
+
+    /**
+     * Auditoría SCRUM-334: destroy no tenía FormRequest — cualquier autenticado
+     * podía eliminar un país sin ningún permiso.
+     */
+    public function test_cannot_delete_country_without_permission()
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user);
+
+        $country = Country::create([
+            'name' => 'Ecuador',
+            'code' => 'EC0001',
+            'status' => Constant::STATUS_ACTIVE,
+        ]);
+
+        $response = $this->deleteJson("/api/v1/countries/{$country->id}");
+
+        $response->assertStatus(403);
+        $this->assertDatabaseHas('countries', ['id' => $country->id]);
+    }
 }

--- a/app/backend/tests/Feature/Api/V1/DocumentDeleteTest.php
+++ b/app/backend/tests/Feature/Api/V1/DocumentDeleteTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Constants\Constant;
+use App\Models\Commerce;
+use App\Models\CommerceDocument;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+/**
+ * SCRUM-316 — DestroyDocumentUploadRequest validaba provider.products.delete (permiso
+ * ajeno a documentos, sin ownership). Ahora exige provider.documents.delete + ownership.
+ */
+class DocumentDeleteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Permission::findOrCreate('provider.documents.delete', 'sanctum');
+        Permission::findOrCreate('provider.products.delete', 'sanctum');
+        Permission::findOrCreate('admin.providers.documents.manage', 'sanctum');
+    }
+
+    private function documentForCommerce(int $commerceId): CommerceDocument
+    {
+        return CommerceDocument::factory()->create([
+            'commerce_id' => $commerceId,
+            'upload_status' => Constant::UPLOAD_STATUS_CONFIRMED,
+        ]);
+    }
+
+    public function test_owner_with_documents_delete_permission_can_delete(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('provider.documents.delete');
+        $this->actingAs($user, 'sanctum');
+
+        $commerce = Commerce::factory()->create(['owner_user_id' => $user->id]);
+        $document = $this->documentForCommerce($commerce->id);
+
+        $response = $this->deleteJson("/api/v1/documents/{$document->id}");
+
+        $response->assertStatus(204);
+        $this->assertSoftDeleted('commerce_documents', ['id' => $document->id]);
+    }
+
+    public function test_foreign_provider_cannot_delete(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('provider.documents.delete');
+        $this->actingAs($user, 'sanctum');
+
+        $foreignCommerce = Commerce::factory()->create();
+        $document = $this->documentForCommerce($foreignCommerce->id);
+
+        $response = $this->deleteJson("/api/v1/documents/{$document->id}");
+
+        $response->assertStatus(403);
+        $this->assertDatabaseHas('commerce_documents', ['id' => $document->id, 'deleted_at' => null]);
+    }
+
+    public function test_products_delete_permission_alone_is_no_longer_sufficient(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('provider.products.delete');
+        $this->actingAs($user, 'sanctum');
+
+        $commerce = Commerce::factory()->create(['owner_user_id' => $user->id]);
+        $document = $this->documentForCommerce($commerce->id);
+
+        $response = $this->deleteJson("/api/v1/documents/{$document->id}");
+
+        $response->assertStatus(403);
+    }
+
+    public function test_admin_permission_bypasses_ownership_check(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('admin.providers.documents.manage');
+        $this->actingAs($user, 'sanctum');
+
+        $foreignCommerce = Commerce::factory()->create();
+        $document = $this->documentForCommerce($foreignCommerce->id);
+
+        $response = $this->deleteJson("/api/v1/documents/{$document->id}");
+
+        $response->assertStatus(204);
+    }
+
+    public function test_nonexistent_document_returns_404(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('provider.documents.delete');
+        $this->actingAs($user, 'sanctum');
+
+        $response = $this->deleteJson('/api/v1/documents/999999');
+
+        $response->assertStatus(404);
+    }
+}

--- a/app/backend/tests/Feature/Api/V1/DocumentDownloadUrlTest.php
+++ b/app/backend/tests/Feature/Api/V1/DocumentDownloadUrlTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Constants\Constant;
+use App\Models\Commerce;
+use App\Models\CommerceDocument;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Tests\TestCase;
+
+/**
+ * SCRUM-315 — IDOR en download-url: el endpoint debe exigir ownership del comercio
+ * dueño del documento (o permiso admin) antes de generar la URL firmada.
+ */
+class DocumentDownloadUrlTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Permission::findOrCreate('provider.documents.view', 'sanctum');
+        Permission::findOrCreate('admin.providers.documents.manage', 'sanctum');
+    }
+
+    private function documentForCommerce(int $commerceId): CommerceDocument
+    {
+        return CommerceDocument::factory()->create([
+            'commerce_id' => $commerceId,
+            'upload_status' => Constant::UPLOAD_STATUS_CONFIRMED,
+        ]);
+    }
+
+    public function test_owner_can_get_download_url(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('provider.documents.view');
+        $this->actingAs($user, 'sanctum');
+
+        $commerce = Commerce::factory()->create(['owner_user_id' => $user->id]);
+        $document = $this->documentForCommerce($commerce->id);
+
+        $response = $this->postJson("/api/v1/documents/{$document->id}/download-url");
+
+        $response->assertOk()
+            ->assertJsonStructure(['data' => ['document_id', 'url', 'expires_at', 'expired_in_seconds']]);
+    }
+
+    public function test_foreign_provider_cannot_get_download_url(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('provider.documents.view');
+        $this->actingAs($user, 'sanctum');
+
+        $foreignCommerce = Commerce::factory()->create();
+        $document = $this->documentForCommerce($foreignCommerce->id);
+
+        $response = $this->postJson("/api/v1/documents/{$document->id}/download-url");
+
+        $response->assertStatus(403);
+    }
+
+    public function test_user_without_permission_cannot_get_download_url(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user, 'sanctum');
+
+        $commerce = Commerce::factory()->create(['owner_user_id' => $user->id]);
+        $document = $this->documentForCommerce($commerce->id);
+
+        $response = $this->postJson("/api/v1/documents/{$document->id}/download-url");
+
+        $response->assertStatus(403);
+    }
+
+    public function test_admin_permission_bypasses_ownership_check(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('admin.providers.documents.manage');
+        $this->actingAs($user, 'sanctum');
+
+        $foreignCommerce = Commerce::factory()->create();
+        $document = $this->documentForCommerce($foreignCommerce->id);
+
+        $response = $this->postJson("/api/v1/documents/{$document->id}/download-url");
+
+        $response->assertOk();
+    }
+
+    public function test_nonexistent_document_returns_404(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('provider.documents.view');
+        $this->actingAs($user, 'sanctum');
+
+        $response = $this->postJson('/api/v1/documents/999999/download-url');
+
+        $response->assertStatus(404);
+    }
+
+    public function test_unauthenticated_user_cannot_get_download_url(): void
+    {
+        $commerce = Commerce::factory()->create();
+        $document = $this->documentForCommerce($commerce->id);
+
+        $response = $this->postJson("/api/v1/documents/{$document->id}/download-url");
+
+        $response->assertStatus(401);
+    }
+}

--- a/app/backend/tests/Feature/Api/V1/DocumentUploadControllerTest.php
+++ b/app/backend/tests/Feature/Api/V1/DocumentUploadControllerTest.php
@@ -18,7 +18,7 @@ class DocumentUploadControllerTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        Permission::create(['name' => 'admin.providers.upload_documents', 'guard_name' => 'sanctum']);
+        Permission::create(['name' => 'admin.providers.documents.manage', 'guard_name' => 'sanctum']);
         $this->setUpMockS3Disk();
     }
 
@@ -29,7 +29,7 @@ class DocumentUploadControllerTest extends TestCase
     {
         $user = User::factory()->create();
         // Asignar permiso necesario
-        $user->givePermissionTo('admin.providers.upload_documents');
+        $user->givePermissionTo('admin.providers.documents.manage');
         $this->actingAs($user);
 
         $payload = [
@@ -60,7 +60,7 @@ class DocumentUploadControllerTest extends TestCase
     public function test_confirm_document_upload_success()
     {
         $user = User::factory()->create();
-        $user->givePermissionTo('admin.providers.upload_documents');
+        $user->givePermissionTo('admin.providers.documents.manage');
         $this->actingAs($user);
 
         // Simular documento pendiente
@@ -107,7 +107,7 @@ class DocumentUploadControllerTest extends TestCase
     public function test_document_token_not_found()
     {
         $user = User::factory()->create();
-        $user->givePermissionTo('admin.providers.upload_documents');
+        $user->givePermissionTo('admin.providers.documents.manage');
         $this->actingAs($user);
 
         $payload = [
@@ -133,7 +133,7 @@ class DocumentUploadControllerTest extends TestCase
     public function test_token_exists_but_not_pending()
     {
         $user = User::factory()->create();
-        $user->givePermissionTo('admin.providers.upload_documents');
+        $user->givePermissionTo('admin.providers.documents.manage');
         $this->actingAs($user);
 
         // Simular documento que no está en estado pendiente
@@ -165,7 +165,7 @@ class DocumentUploadControllerTest extends TestCase
     public function test_presigned_url_expired()
     {
         $user = User::factory()->create();
-        $user->givePermissionTo('admin.providers.upload_documents');
+        $user->givePermissionTo('admin.providers.documents.manage');
         $this->actingAs($user);
         // Simular documento pendiente pero expirado
         $document = CommerceDocument::factory()->create([
@@ -196,7 +196,7 @@ class DocumentUploadControllerTest extends TestCase
     public function test_confirm_supersedes_previous_document_of_same_type()
     {
         $user = User::factory()->create();
-        $user->givePermissionTo('admin.providers.upload_documents');
+        $user->givePermissionTo('admin.providers.documents.manage');
         $this->actingAs($user);
 
         $commerce = Commerce::factory()->create();
@@ -244,7 +244,7 @@ class DocumentUploadControllerTest extends TestCase
     public function test_confirmed_documents_list_excludes_superseded_document()
     {
         $user = User::factory()->create();
-        $user->givePermissionTo('admin.providers.upload_documents');
+        $user->givePermissionTo('admin.providers.documents.manage');
         $this->actingAs($user);
 
         $commerce = Commerce::factory()->create();
@@ -287,7 +287,7 @@ class DocumentUploadControllerTest extends TestCase
     public function test_confirm_does_not_affect_document_of_different_type()
     {
         $user = User::factory()->create();
-        $user->givePermissionTo('admin.providers.upload_documents');
+        $user->givePermissionTo('admin.providers.documents.manage');
         $this->actingAs($user);
 
         $commerce = Commerce::factory()->create();
@@ -334,7 +334,7 @@ class DocumentUploadControllerTest extends TestCase
     public function test_confirm_chains_three_versions_of_the_same_document()
     {
         $user = User::factory()->create();
-        $user->givePermissionTo('admin.providers.upload_documents');
+        $user->givePermissionTo('admin.providers.documents.manage');
         $this->actingAs($user);
 
         $commerce = Commerce::factory()->create();
@@ -405,7 +405,7 @@ class DocumentUploadControllerTest extends TestCase
     public function test_confirm_first_document_of_its_type_does_not_supersede_anything()
     {
         $user = User::factory()->create();
-        $user->givePermissionTo('admin.providers.upload_documents');
+        $user->givePermissionTo('admin.providers.documents.manage');
         $this->actingAs($user);
 
         $document = CommerceDocument::factory()->create([
@@ -637,7 +637,7 @@ class DocumentUploadControllerTest extends TestCase
     }
 
     /**
-     * Regresión del retiro de admin.providers.upload_documents del rol provider
+     * Regresión del retiro de admin.providers.documents.manage del rol provider
      * (Tarea 2, SCRUM-242): el usuario con el permiso admin sigue operando
      * cualquier comercio sin verificación de ownership.
      *
@@ -646,7 +646,7 @@ class DocumentUploadControllerTest extends TestCase
     public function test_admin_permission_bypasses_ownership_check()
     {
         $user = User::factory()->create();
-        $user->givePermissionTo('admin.providers.upload_documents');
+        $user->givePermissionTo('admin.providers.documents.manage');
         $this->actingAs($user);
 
         $foreignCommerce = Commerce::factory()->create();

--- a/app/backend/tests/Feature/Api/V1/LoginTest.php
+++ b/app/backend/tests/Feature/Api/V1/LoginTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Constants\Constant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+/**
+ * Cobertura de SCRUM-325: el login valida el ámbito (módulo) y el estado del usuario.
+ */
+class LoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        foreach (['superadmin', 'admin', 'support', 'provider', 'branch_leader', 'user'] as $role) {
+            Role::create(['name' => $role, 'guard_name' => 'sanctum']);
+        }
+    }
+
+    /**
+     * Crea un usuario activo con la contraseña por defecto del factory ('password') y un rol.
+     */
+    private function userWithRole(string $role, int $status = Constant::STATUS_ACTIVE): User
+    {
+        $user = User::factory()->create(['status' => $status]);
+        $user->assignRole($role);
+
+        return $user;
+    }
+
+    private function attemptLogin(User $user, string $scope): \Illuminate\Testing\TestResponse
+    {
+        return $this->postJson('/api/v1/login', [
+            'email' => $user->email,
+            'password' => 'password',
+            'scope' => $scope,
+        ]);
+    }
+
+    // ---- Flujo feliz por ámbito -------------------------------------------------
+
+    public function test_provider_can_login_with_provider_scope(): void
+    {
+        $user = $this->userWithRole('provider');
+
+        $this->attemptLogin($user, 'provider')
+            ->assertOk()
+            ->assertJsonPath('message', 'Login successful')
+            ->assertJsonStructure(['token', 'data' => ['id', 'email', 'roles']]);
+    }
+
+    public function test_branch_leader_can_login_with_provider_scope(): void
+    {
+        $user = $this->userWithRole('branch_leader');
+
+        $this->attemptLogin($user, 'provider')->assertOk();
+    }
+
+    public function test_admin_can_login_with_admin_scope(): void
+    {
+        $user = $this->userWithRole('admin');
+
+        $this->attemptLogin($user, 'admin')->assertOk();
+    }
+
+    public function test_customer_can_login_with_customer_scope(): void
+    {
+        $user = $this->userWithRole('user');
+
+        $this->attemptLogin($user, 'customer')->assertOk();
+    }
+
+    // ---- Rechazo por ámbito ajeno (estricto) ------------------------------------
+
+    public function test_customer_cannot_login_on_admin_scope(): void
+    {
+        $user = $this->userWithRole('user');
+
+        $response = $this->attemptLogin($user, 'admin');
+
+        $response->assertStatus(422)
+            ->assertJsonMissingPath('token')
+            ->assertJsonValidationErrors('email');
+    }
+
+    public function test_customer_cannot_login_on_provider_scope(): void
+    {
+        $user = $this->userWithRole('user');
+
+        $this->attemptLogin($user, 'provider')
+            ->assertStatus(422)
+            ->assertJsonMissingPath('token');
+    }
+
+    public function test_admin_cannot_login_on_provider_scope_strict(): void
+    {
+        $user = $this->userWithRole('admin');
+
+        $this->attemptLogin($user, 'provider')
+            ->assertStatus(422)
+            ->assertJsonMissingPath('token');
+    }
+
+    public function test_superadmin_is_strict_and_cannot_login_on_customer_scope(): void
+    {
+        $user = $this->userWithRole('superadmin');
+
+        // Decisión del proyecto: mapa estricto, sin god-mode multi-módulo.
+        $this->attemptLogin($user, 'customer')
+            ->assertStatus(422)
+            ->assertJsonMissingPath('token');
+    }
+
+    // ---- Estado del usuario -----------------------------------------------------
+
+    public function test_inactive_user_cannot_login_even_with_correct_scope(): void
+    {
+        $user = $this->userWithRole('provider', Constant::STATUS_INACTIVE);
+
+        $this->attemptLogin($user, 'provider')
+            ->assertStatus(422)
+            ->assertJsonMissingPath('token');
+    }
+
+    // ---- Validación del campo scope ---------------------------------------------
+
+    public function test_scope_is_required(): void
+    {
+        $user = $this->userWithRole('admin');
+
+        $this->postJson('/api/v1/login', [
+            'email' => $user->email,
+            'password' => 'password',
+        ])->assertStatus(422)->assertJsonValidationErrors('scope');
+    }
+
+    public function test_invalid_scope_is_rejected(): void
+    {
+        $user = $this->userWithRole('admin');
+
+        $this->attemptLogin($user, 'root')
+            ->assertStatus(422)
+            ->assertJsonValidationErrors('scope');
+    }
+
+    // ---- Anti-enumeración: mismo mensaje en las 3 causas ------------------------
+
+    public function test_failure_message_is_identical_across_causes(): void
+    {
+        $wrongPasswordUser = $this->userWithRole('admin');
+        $foreignScopeUser = $this->userWithRole('user');
+        $inactiveUser = $this->userWithRole('admin', Constant::STATUS_INACTIVE);
+
+        $badCredential = $this->postJson('/api/v1/login', [
+            'email' => $wrongPasswordUser->email,
+            'password' => 'incorrect-password',
+            'scope' => 'admin',
+        ])->json('errors.email');
+
+        $foreignScope = $this->attemptLogin($foreignScopeUser, 'admin')->json('errors.email');
+        $inactive = $this->attemptLogin($inactiveUser, 'admin')->json('errors.email');
+
+        $this->assertSame($badCredential, $foreignScope);
+        $this->assertSame($badCredential, $inactive);
+    }
+}

--- a/app/backend/tests/Feature/Api/V1/ProductPhotoRemoveTest.php
+++ b/app/backend/tests/Feature/Api/V1/ProductPhotoRemoveTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Api\V1;
 
+use App\Models\Commerce;
+use App\Models\Product;
 use App\Models\ProductPhoto;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -17,16 +19,19 @@ class ProductPhotoRemoveTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        // Crear el permiso si no existe
-        Permission::findOrCreate('provider.products.delete', 'sanctum');
+        Permission::findOrCreate('provider.photos.delete', 'sanctum');
+        Permission::findOrCreate('admin.providers.documents.manage', 'sanctum');
     }
 
     public function test_remove_photo_success(): void
     {
         $user = User::factory()->create();
-        $user->givePermissionTo('provider.products.delete');
+        $user->givePermissionTo('provider.photos.delete');
         $this->actingAs($user, 'sanctum');
-        $photo = ProductPhoto::factory()->create();
+
+        $commerce = Commerce::factory()->create(['owner_user_id' => $user->id]);
+        $product = Product::factory()->create(['commerce_id' => $commerce->id]);
+        $photo = ProductPhoto::factory()->create(['product_id' => $product->id]);
 
         $response = $this->deleteJson('/api/v1/products/commerce/photos/'.$photo->id);
         $response->assertStatus(204);
@@ -36,9 +41,51 @@ class ProductPhotoRemoveTest extends TestCase
     public function test_remove_photo_not_found(): void
     {
         $user = User::factory()->create();
-        $user->givePermissionTo('provider.products.delete');
+        $user->givePermissionTo('provider.photos.delete');
         $this->actingAs($user, 'sanctum');
         $response = $this->deleteJson('/api/v1/products/commerce/photos/999999');
         $response->assertStatus(404);
+    }
+
+    public function test_remove_photo_of_foreign_commerce_is_forbidden(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('provider.photos.delete');
+        $this->actingAs($user, 'sanctum');
+
+        $foreignCommerce = Commerce::factory()->create();
+        $product = Product::factory()->create(['commerce_id' => $foreignCommerce->id]);
+        $photo = ProductPhoto::factory()->create(['product_id' => $product->id]);
+
+        $response = $this->deleteJson('/api/v1/products/commerce/photos/'.$photo->id);
+        $response->assertStatus(403);
+        $this->assertDatabaseHas('product_photos', ['id' => $photo->id, 'deleted_at' => null]);
+    }
+
+    public function test_remove_photo_without_permission_is_forbidden(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user, 'sanctum');
+
+        $commerce = Commerce::factory()->create(['owner_user_id' => $user->id]);
+        $product = Product::factory()->create(['commerce_id' => $commerce->id]);
+        $photo = ProductPhoto::factory()->create(['product_id' => $product->id]);
+
+        $response = $this->deleteJson('/api/v1/products/commerce/photos/'.$photo->id);
+        $response->assertStatus(403);
+    }
+
+    public function test_admin_permission_bypasses_ownership_check(): void
+    {
+        $user = User::factory()->create();
+        $user->givePermissionTo('admin.providers.documents.manage');
+        $this->actingAs($user, 'sanctum');
+
+        $foreignCommerce = Commerce::factory()->create();
+        $product = Product::factory()->create(['commerce_id' => $foreignCommerce->id]);
+        $photo = ProductPhoto::factory()->create(['product_id' => $product->id]);
+
+        $response = $this->deleteJson('/api/v1/products/commerce/photos/'.$photo->id);
+        $response->assertStatus(204);
     }
 }

--- a/app/backend/tests/Feature/Api/V1/SupportStatusTest.php
+++ b/app/backend/tests/Feature/Api/V1/SupportStatusTest.php
@@ -110,4 +110,27 @@ class SupportStatusTest extends TestCase
         $response = $this->postJson('/api/v1/support-statuses', $payload);
         $response->assertForbidden();
     }
+
+    /**
+     * Auditoría SCRUM-334: show/destroy no tenían FormRequest — cualquier
+     * autenticado podía ver/eliminar un estado de soporte sin ningún permiso.
+     */
+    public function test_cannot_show_support_status_without_permission()
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user);
+        $status = SupportStatus::factory()->create();
+        $response = $this->getJson('/api/v1/support-statuses/'.$status->id);
+        $response->assertForbidden();
+    }
+
+    public function test_cannot_delete_support_status_without_permission()
+    {
+        $user = User::factory()->create();
+        Sanctum::actingAs($user);
+        $status = SupportStatus::factory()->create();
+        $response = $this->deleteJson('/api/v1/support-statuses/'.$status->id);
+        $response->assertForbidden();
+        $this->assertDatabaseHas('support_statuses', ['id' => $status->id, 'deleted_at' => null]);
+    }
 }

--- a/app/backend/tests/Feature/AuditLogTest.php
+++ b/app/backend/tests/Feature/AuditLogTest.php
@@ -10,16 +10,29 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Laravel\Sanctum\Sanctum;
 use PHPUnit\Framework\Attributes\Covers;
+use Spatie\Permission\Models\Permission;
 use Tests\TestCase;
 
+/**
+ * Cobertura de estructura/contenido del recurso. La matriz de autorización
+ * (con/sin permiso, 401, 404) vive en AuditLogAuthorizationTest (SCRUM-334).
+ */
 #[Covers(AuditLogController::class)]
 class AuditLogTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Permission::findOrCreate('admin.audit_logs.index', 'sanctum');
+        Permission::findOrCreate('admin.audit_logs.show', 'sanctum');
+    }
+
     public function test_authenticated_user_can_list_audit_logs(): void
     {
         $user = User::factory()->create();
+        $user->givePermissionTo('admin.audit_logs.index');
         AuditLog::factory()->count(3)->create();
         Sanctum::actingAs($user);
 
@@ -41,6 +54,7 @@ class AuditLogTest extends TestCase
     public function test_authenticated_user_can_view_a_single_audit_log(): void
     {
         $user = User::factory()->create();
+        $user->givePermissionTo('admin.audit_logs.show');
         $log = AuditLog::factory()->create();
         Sanctum::actingAs($user);
 
@@ -55,6 +69,7 @@ class AuditLogTest extends TestCase
     public function test_not_found_for_nonexistent_audit_log(): void
     {
         $user = User::factory()->create();
+        $user->givePermissionTo('admin.audit_logs.show');
         Sanctum::actingAs($user);
         $response = $this->getJson('/api/v1/audit-logs/99999');
         $response->assertNotFound();

--- a/app/backend/tests/Unit/Api/V1/AuthServiceTest.php
+++ b/app/backend/tests/Unit/Api/V1/AuthServiceTest.php
@@ -9,6 +9,7 @@ use App\Services\AuthService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\ValidationException;
+use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 class AuthServiceTest extends TestCase
@@ -28,14 +29,18 @@ class AuthServiceTest extends TestCase
      */
     public function test_login_succeeds_with_valid_credentials()
     {
+        Role::create(['name' => 'user', 'guard_name' => 'sanctum']);
+
         $user = User::factory()->create([
             'email' => 'test@example.com',
             'password' => Hash::make('password123'),
         ]);
+        $user->assignRole('user');
 
         $result = $this->authService->login([
             'email' => 'test@example.com',
             'password' => 'password123',
+            'scope' => 'customer',
         ]);
 
         $this->assertArrayHasKey('token', $result);

--- a/app/frontend/src/components/admin/login-form.tsx
+++ b/app/frontend/src/components/admin/login-form.tsx
@@ -47,7 +47,7 @@ export function LoginForm({ onSubmit, labels }: LoginFormProps) {
           last_name: ''
         };
       } else {
-        const result = await login({ email, password });
+        const result = await login({ email, password, scope: "admin" });
         redirectTo = result.redirectTo ?? redirectTo;
         
         // Usar datos del usuario de la respuesta de la API

--- a/app/frontend/src/hooks/use-auth-form.ts
+++ b/app/frontend/src/hooks/use-auth-form.ts
@@ -78,10 +78,11 @@ export function useAuthForm(): UseAuthFormReturn {
         throw new Error("La contraseña debe tener al menos 6 caracteres");
       }
 
-      // Llamar a API
+      // Llamar a API (este hook sirve a la superficie de proveedor)
       const result = await login({
         email: sanitizedEmail,
         password: sanitizedPassword,
+        scope: "provider",
       });
 
       if (!result.ok || !result.user) {

--- a/app/frontend/src/lib/api/app-auth.ts
+++ b/app/frontend/src/lib/api/app-auth.ts
@@ -129,7 +129,7 @@ async function parseAuthResponse(response: Response): Promise<LoginResponse> {
  * Uses shared login endpoint but remains separate from provider auth module.
  */
 export async function loginAppUser({ email, password }: AppLoginPayload): Promise<AppLoginResult> {
-  return login({ email, password });
+  return login({ email, password, scope: "customer" });
 }
 
 /**

--- a/app/frontend/src/lib/api/auth.ts
+++ b/app/frontend/src/lib/api/auth.ts
@@ -11,9 +11,17 @@ import { API_URL, ApiError } from "./client";
 // Types
 // ============================================
 
+/**
+ * Ámbito/módulo desde el que se inicia sesión. El backend valida que el rol del
+ * usuario pertenezca a este ámbito (SCRUM-325). El nombre de la clave `scope` debe
+ * coincidir exactamente con el que lee el backend (LoginRequest).
+ */
+export type LoginScope = "admin" | "provider" | "customer";
+
 type LoginPayload = {
   email: string;
   password: string;
+  scope: LoginScope;
 };
 
 type ForgotPasswordPayload = {
@@ -72,7 +80,7 @@ async function readErrorBody(response: Response): Promise<unknown> {
  * POST /api/v1/login
  * Autentica usuario y retorna token + datos de sesión
  */
-export async function login({ email, password }: LoginPayload): Promise<LoginResult> {
+export async function login({ email, password, scope }: LoginPayload): Promise<LoginResult> {
   if (!email || !password) {
     throw new ApiError("Ingresa correo y contraseña.", 422);
   }
@@ -80,11 +88,11 @@ export async function login({ email, password }: LoginPayload): Promise<LoginRes
   try {
     const response = await fetch(`${API_URL}/api/v1/login`, {
       method: "POST",
-      headers: { 
+      headers: {
         "Content-Type": "application/json",
         "Accept": "application/json"
       },
-      body: JSON.stringify({ email, password }),
+      body: JSON.stringify({ email, password, scope }),
     });
 
     if (!response.ok) {

--- a/docs/backend-endpoints-v2.md
+++ b/docs/backend-endpoints-v2.md
@@ -499,7 +499,7 @@ Body: {"name":"Delete","description":"Delete","permissions":["admin.profiles.rol
   - `mime_type` en whitelist (pdf, jpg, png, docx) → 422 si inválido.
   - `file_size_bytes` máximo 50MB → 422 si excede.
   - `commerce_id` debe existir → 404 si no existe.
-  - Permiso `admin.providers.upload_documents` → 403 si sin permisos.
+  - Permiso `admin.providers.documents.manage` → 403 si sin permisos.
 - **Respuesta exitosa (201 CREATED):**
   ```json
   {


### PR DESCRIPTION
## Summary
- **SCRUM-325**: el login exige un `scope` (admin/provider/customer) validado en la capa autoritativa — cierra el hueco donde cualquier usuario podía loguearse en el login de cualquier módulo. Valida también estado activo del usuario; mensaje genérico único para credencial inválida / ámbito ajeno / inactivo (anti-enumeración).
- **SCRUM-334/315/316**: auditoría de ~100 endpoints bajo `auth:sanctum`. Corrige el IDOR en `download-url` (315) y el permiso incorrecto de `DestroyDocumentUploadRequest` (316), que en realidad protegía 3 endpoints sin ownership real (documento, foto de producto, foto de sucursal) — se separan en FormRequests dedicados con permisos granulares. Cierra además 5 huecos triviales encontrados en la auditoría (audit-logs sin ningún check, 2 endpoints de catálogo sin FormRequest).
- Renombra `admin.providers.upload_documents` → `admin.providers.documents.manage` (bypass admin unificado, asignado también al rol `admin`, no solo `superadmin`).
- Corrige de paso una regresión no detectada: el registro de provider/customer llamaba a `AuthService::login()` sin el `scope` ahora obligatorio.

## Test plan
- [x] Suite completa del backend: 387/387 tests passed (`php artisan test` en `infra-backend-1`)
- [x] Pint sin diffs pendientes en todos los archivos tocados
- [x] `migrate:fresh --seed` verificado idempotente (permisos nuevos asignados por rol, permiso viejo eliminado)
- [x] `tsc --noEmit` limpio en frontend (envío de `scope` desde las 3 superficies de login)
- [ ] QA manual: reproducir los pasos de SCRUM-325 (login cruzado entre módulos) y de SCRUM-315/316 (IDOR de documentos, permiso de borrado)

Jira: SCRUM-325, SCRUM-334, SCRUM-315, SCRUM-316 → Pruebas funcionales · SCRUM-343 creado (decisión de producto derivada) · SCRUM-273 anexado con hallazgo colateral

