### PR TITLE
fix(emails): limpiar redundancias en correos de rechazo y verificacion

### DIFF
--- a/app/backend/resources/views/emails/commerce-rejected.blade.php
+++ b/app/backend/resources/views/emails/commerce-rejected.blade.php
@@ -31,8 +31,8 @@
         <tr>
           <td class="fnt" style="font-family:'DM Sans', Arial, sans-serif; font-size:15px; line-height:1.7; color:#333333;">
             <p style="margin:0 0 16px 0; font-weight:600;">Hola {{ $notifiable->name ?? 'Usuario' }},</p>
-            <p style="margin:0 0 16px 0;">Lamentamos informarte que tu comercio "{{ $commerce->name }}" ha sido rechazado tras el proceso de verificación.</p>
-            <p style="margin:0 0 16px 0;">Por favor revisa la información registrada y vuelve a intentarlo o contacta soporte para más detalles.</p>
+            <p style="margin:0 0 16px 0;">Lamentamos informarte que tu comercio ha sido rechazado tras el proceso de verificación.</p>
+            <p style="margin:0 0 16px 0;">El motivo del rechazo es:</p>
             <p style="margin:0 0 16px 0; color:#666666; font-style:italic;">{{ $customMessage }}</p>
             <p style="margin:0 0 16px 0;">Gracias por tu interés en nuestra plataforma.</p>
             <p style="margin:0;">Saludos,<br>Tu amigo Ñapa<br>Email: soporte@napaapp.com.co</p>

--- a/app/backend/resources/views/emails/commerce-verified.blade.php
+++ b/app/backend/resources/views/emails/commerce-verified.blade.php
@@ -26,8 +26,7 @@
         <tr>
           <td class="fnt" style="font-family:'DM Sans', Arial, sans-serif; font-size:15px; line-height:1.7; color:#333333;">
             <p style="margin:0 0 16px 0;">Hola {{ $notifiable->name }},</p>
-            <p style="margin:0 0 16px 0;">Nos complace informarte que tu comercio "{{ $commerce->name }}" ha sido verificado y ahora se encuentra activo en la plataforma.</p>
-            <p style="margin:0 0 16px 0;">Su registro como proveedor ha sido aprobado satisfactoriamente.</p>
+            <p style="margin:0 0 16px 0;">Nos complace informarte que tu comercio ha sido verificado y ahora se encuentra activo en la plataforma.</p>
             @if($customMessage)
             <p style="margin:0 0 16px 0;">{{ $customMessage }}</p>
             @endif


### PR DESCRIPTION
## Summary
- **SCRUM-320** (email de rechazo): quita el nombre del comercio del cuerpo — queda solo en el saludo — y reemplaza la frase genérica "Por favor revisa la información…" por **"El motivo del rechazo es:"**, que conecta directo con el mensaje personalizado del motivo que aparece justo debajo.
- **SCRUM-321** (email de verificación exitosa): quita el nombre del comercio del cuerpo y elimina la frase duplicada "Su registro como proveedor ha sido aprobado satisfactoriamente" (redundante con "ha sido verificado y ahora se encuentra activo").
- Solo edición de texto en 2 plantillas Blade — sin cambios de lógica, datos ni contrato.

## Test plan
- [x] Renderizado real de ambas plantillas con datos de prueba: nombre de comercio ausente del cuerpo, frase nueva presente (320), frase duplicada eliminada (321), `customMessage` y saludo intactos.
- [x] `NotificationQueueTest` + `PatchCommerceVerificationTest`: 14/14 passed (`infra-backend-1`).
- [x] Pint PASS.
- [ ] QA: reproducir aprobación/rechazo de proveedor desde admin y revisar los correos recibidos.

Jira: SCRUM-320, SCRUM-321 → Pruebas funcionales (asignados a Daniel Castro).