### PR TITLE
fix(a11y): comunicar obligatoriedad, errores y estados en FileUploadBox (SCRUM-317)

### DIFF
--- a/app/frontend/src/components/provider/forms/camara-comercio-card.tsx
+++ b/app/frontend/src/components/provider/forms/camara-comercio-card.tsx
@@ -52,11 +52,13 @@ export function CamaraComercioCard({
       <CardContent className="space-y-4">
         <div className="flex flex-col space-y-2">
           <Label className="text-sm font-medium text-[#1A1A1A]">
-            Documento de Cámara de Comercio <span className="text-red-500">*</span>
+            Documento de Cámara de Comercio <span className="text-red-500" aria-hidden="true">*</span>
+            <span className="sr-only"> (obligatorio)</span>
           </Label>
           <FileUploadBox
             label="Carga el documento de Cámara de Comercio"
             fileName={documents.commerceChamber}
+            describedById="commerce-chamber-status"
             onUpload={async () => {
               const { openFileDialog, validateFile, generateFileName } = await import('@/lib/utils/file-upload');
               const file = await openFileDialog();
@@ -75,24 +77,26 @@ export function CamaraComercioCard({
             }}
             disabled={isUploadingCamara || uploadStatus === 'uploading'}
           />
-          {uploadStatus === 'uploading' && (
-            <p className="text-xs text-[#6A6A6A]">Subiendo documento...</p>
-          )}
-          {uploadStatus === 'success' && (
-            <p className="text-xs text-green-600">Documento cargado correctamente.</p>
-          )}
-          {uploadStatus === 'error' && uploadError && (
-            <div className="flex items-center gap-2 text-xs text-red-600">
-              <AlertCircle size={14} />
-              <span>{uploadError}</span>
-            </div>
-          )}
-          {errors.commerceChamber && (
-            <div className="flex items-center gap-2 text-xs text-red-600">
-              <AlertCircle size={14} />
-              <span>{errors.commerceChamber}</span>
-            </div>
-          )}
+          <div id="commerce-chamber-status" aria-live="polite">
+            {uploadStatus === 'uploading' && (
+              <p className="text-xs text-[#6A6A6A]">Subiendo documento...</p>
+            )}
+            {uploadStatus === 'success' && (
+              <p className="text-xs text-green-600">Documento cargado correctamente.</p>
+            )}
+            {uploadStatus === 'error' && uploadError && (
+              <div className="flex items-center gap-2 text-xs text-red-600">
+                <AlertCircle size={14} />
+                <span>{uploadError}</span>
+              </div>
+            )}
+            {errors.commerceChamber && (
+              <div className="flex items-center gap-2 text-xs text-red-600">
+                <AlertCircle size={14} />
+                <span>{errors.commerceChamber}</span>
+              </div>
+            )}
+          </div>
         </div>
       </CardContent>
     </Card>

--- a/app/frontend/src/components/provider/forms/representante-legal-card.tsx
+++ b/app/frontend/src/components/provider/forms/representante-legal-card.tsx
@@ -105,25 +105,31 @@ export function RepresentanteLegalCard({
           {/* ============================================ */}
           <div className="flex flex-col space-y-2">
             <Label htmlFor="legalRep-firstName" className="text-sm font-medium text-[#1A1A1A]">
-              Nombres <span className="text-red-500">*</span>
+              Nombres <span className="text-red-500" aria-hidden="true">*</span>
+              <span className="sr-only"> (obligatorio)</span>
             </Label>
             <Input
               id="legalRep-firstName"
               placeholder="Ej: Juan Pedro"
               value={legalRepresentative.firstName}
               onChange={(e) => handleRepChange('firstName', formatLettersOnly(e.target.value))}
+              aria-required="true"
+              aria-invalid={!!errors.legalRepresentativeFirstName}
+              aria-describedby="legalRep-firstName-status"
               className={`h-[50px] rounded-[14px] border ${
                 errors.legalRepresentativeFirstName
                   ? 'border-red-500 bg-red-50'
                   : 'border-[#E0E0E0] bg-white'
               }`}
             />
-            {errors.legalRepresentativeFirstName && (
-              <div className="flex items-center gap-2 text-xs text-red-600">
-                <AlertCircle size={14} />
-                <span>{errors.legalRepresentativeFirstName}</span>
-              </div>
-            )}
+            <div id="legalRep-firstName-status" aria-live="polite">
+              {errors.legalRepresentativeFirstName && (
+                <div className="flex items-center gap-2 text-xs text-red-600">
+                  <AlertCircle size={14} />
+                  <span>{errors.legalRepresentativeFirstName}</span>
+                </div>
+              )}
+            </div>
           </div>
 
           {/* ============================================ */}
@@ -131,25 +137,31 @@ export function RepresentanteLegalCard({
           {/* ============================================ */}
           <div className="flex flex-col space-y-2">
             <Label htmlFor="legalRep-lastName" className="text-sm font-medium text-[#1A1A1A]">
-              Apellidos <span className="text-red-500">*</span>
+              Apellidos <span className="text-red-500" aria-hidden="true">*</span>
+              <span className="sr-only"> (obligatorio)</span>
             </Label>
             <Input
               id="legalRep-lastName"
               placeholder="Ej: García López"
               value={legalRepresentative.lastName}
               onChange={(e) => handleRepChange('lastName', formatLettersOnly(e.target.value))}
+              aria-required="true"
+              aria-invalid={!!errors.legalRepresentativeLastName}
+              aria-describedby="legalRep-lastName-status"
               className={`h-[50px] rounded-[14px] border ${
                 errors.legalRepresentativeLastName
                   ? 'border-red-500 bg-red-50'
                   : 'border-[#E0E0E0] bg-white'
               }`}
             />
-            {errors.legalRepresentativeLastName && (
-              <div className="flex items-center gap-2 text-xs text-red-600">
-                <AlertCircle size={14} />
-                <span>{errors.legalRepresentativeLastName}</span>
-              </div>
-            )}
+            <div id="legalRep-lastName-status" aria-live="polite">
+              {errors.legalRepresentativeLastName && (
+                <div className="flex items-center gap-2 text-xs text-red-600">
+                  <AlertCircle size={14} />
+                  <span>{errors.legalRepresentativeLastName}</span>
+                </div>
+              )}
+            </div>
           </div>
 
           {/* ============================================ */}
@@ -157,7 +169,8 @@ export function RepresentanteLegalCard({
           {/* ============================================ */}
           <div className="flex flex-col space-y-2">
             <Label htmlFor="legalRep-docType" className="text-sm font-medium text-[#1A1A1A]">
-              Tipo de Documento <span className="text-red-500">*</span>
+              Tipo de Documento <span className="text-red-500" aria-hidden="true">*</span>
+              <span className="sr-only"> (obligatorio)</span>
             </Label>
             <Select
               value={normalizedDocumentType}
@@ -165,6 +178,9 @@ export function RepresentanteLegalCard({
             >
               <SelectTrigger
                 id="legalRep-docType"
+                aria-required="true"
+                aria-invalid={!!errors.legalRepresentativeDocumentType}
+                aria-describedby="legalRep-docType-status"
                 className={`h-[50px] rounded-[14px] border ${
                   errors.legalRepresentativeDocumentType
                     ? 'border-red-500 bg-red-50'
@@ -181,12 +197,14 @@ export function RepresentanteLegalCard({
                 ))}
               </SelectContent>
             </Select>
-            {errors.legalRepresentativeDocumentType && (
-              <div className="flex items-center gap-2 text-xs text-red-600">
-                <AlertCircle size={14} />
-                <span>{errors.legalRepresentativeDocumentType}</span>
-              </div>
-            )}
+            <div id="legalRep-docType-status" aria-live="polite">
+              {errors.legalRepresentativeDocumentType && (
+                <div className="flex items-center gap-2 text-xs text-red-600">
+                  <AlertCircle size={14} />
+                  <span>{errors.legalRepresentativeDocumentType}</span>
+                </div>
+              )}
+            </div>
           </div>
 
           {/* ============================================ */}
@@ -194,7 +212,8 @@ export function RepresentanteLegalCard({
           {/* ============================================ */}
           <div className="flex flex-col space-y-2">
             <Label htmlFor="legalRep-docNumber" className="text-sm font-medium text-[#1A1A1A]">
-              Número de Documento <span className="text-red-500">*</span>
+              Número de Documento <span className="text-red-500" aria-hidden="true">*</span>
+              <span className="sr-only"> (obligatorio)</span>
             </Label>
             <Input
               id="legalRep-docNumber"
@@ -204,18 +223,23 @@ export function RepresentanteLegalCard({
               onChange={(e) =>
                 handleRepChange('documentNumber', formatDocumentNumber(e.target.value))
               }
+              aria-required="true"
+              aria-invalid={!!errors.legalRepresentativeDocumentNumber}
+              aria-describedby="legalRep-docNumber-status"
               className={`h-[50px] rounded-[14px] border ${
                 errors.legalRepresentativeDocumentNumber
                   ? 'border-red-500 bg-red-50'
                   : 'border-[#E0E0E0] bg-white'
               }`}
             />
-            {errors.legalRepresentativeDocumentNumber && (
-              <div className="flex items-center gap-2 text-xs text-red-600">
-                <AlertCircle size={14} />
-                <span>{errors.legalRepresentativeDocumentNumber}</span>
-              </div>
-            )}
+            <div id="legalRep-docNumber-status" aria-live="polite">
+              {errors.legalRepresentativeDocumentNumber && (
+                <div className="flex items-center gap-2 text-xs text-red-600">
+                  <AlertCircle size={14} />
+                  <span>{errors.legalRepresentativeDocumentNumber}</span>
+                </div>
+              )}
+            </div>
           </div>
 
           {/* ============================================ */}
@@ -223,11 +247,13 @@ export function RepresentanteLegalCard({
           {/* ============================================ */}
           <div className="md:col-span-2 flex flex-col space-y-2">
             <Label className="text-sm font-medium text-[#1A1A1A]">
-              Documento (Cédula/Pasaporte) <span className="text-red-500">*</span>
+              Documento (Cédula/Pasaporte) <span className="text-red-500" aria-hidden="true">*</span>
+              <span className="sr-only"> (obligatorio)</span>
             </Label>
             <FileUploadBox
               label="Carga el documento de identidad"
               fileName={legalRepresentative.documentFile}
+              describedById="legalRep-document-status"
               onUpload={async () => {
                 const { openFileDialog, validateFile, generateFileName } = await import('@/lib/utils/file-upload');
                 const file = await openFileDialog();
@@ -246,24 +272,26 @@ export function RepresentanteLegalCard({
               }}
               disabled={isUploadingDoc || uploadStatus === 'uploading'}
             />
-            {uploadStatus === 'uploading' && (
-              <p className="text-xs text-[#6A6A6A]">Subiendo documento...</p>
-            )}
-            {uploadStatus === 'success' && (
-              <p className="text-xs text-green-600">Documento cargado correctamente.</p>
-            )}
-            {uploadStatus === 'error' && uploadError && (
-              <div className="flex items-center gap-2 text-xs text-red-600">
-                <AlertCircle size={14} />
-                <span>{uploadError}</span>
-              </div>
-            )}
-            {errors.legalRepresentativeDocumentFile && (
-              <div className="flex items-center gap-2 text-xs text-red-600">
-                <AlertCircle size={14} />
-                <span>{errors.legalRepresentativeDocumentFile}</span>
-              </div>
-            )}
+            <div id="legalRep-document-status" aria-live="polite">
+              {uploadStatus === 'uploading' && (
+                <p className="text-xs text-[#6A6A6A]">Subiendo documento...</p>
+              )}
+              {uploadStatus === 'success' && (
+                <p className="text-xs text-green-600">Documento cargado correctamente.</p>
+              )}
+              {uploadStatus === 'error' && uploadError && (
+                <div className="flex items-center gap-2 text-xs text-red-600">
+                  <AlertCircle size={14} />
+                  <span>{uploadError}</span>
+                </div>
+              )}
+              {errors.legalRepresentativeDocumentFile && (
+                <div className="flex items-center gap-2 text-xs text-red-600">
+                  <AlertCircle size={14} />
+                  <span>{errors.legalRepresentativeDocumentFile}</span>
+                </div>
+              )}
+            </div>
           </div>
         </div>
       </CardContent>

--- a/app/frontend/src/components/provider/forms/rut-card.tsx
+++ b/app/frontend/src/components/provider/forms/rut-card.tsx
@@ -59,11 +59,13 @@ export function RutCard({
       <CardContent className="space-y-6">
         <div className="flex flex-col space-y-2">
           <Label className="text-sm font-medium text-[#1A1A1A]">
-            {rutLabel} <span className="text-red-500">*</span>
+            {rutLabel} <span className="text-red-500" aria-hidden="true">*</span>
+            <span className="sr-only"> (obligatorio)</span>
           </Label>
           <FileUploadBox
             label="Carga el RUT"
             fileName={documents.rut}
+            describedById="rut-status"
             onUpload={async () => {
               const { openFileDialog, validateFile, generateFileName } = await import('@/lib/utils/file-upload');
               const file = await openFileDialog();
@@ -82,31 +84,38 @@ export function RutCard({
             }}
             disabled={rutUploadStatus === 'uploading'}
           />
-          {rutUploadStatus === 'uploading' && (
-            <p className="text-xs text-[#6A6A6A]">Subiendo documento...</p>
-          )}
-          {rutUploadStatus === 'success' && (
-            <p className="text-xs text-green-600">Documento cargado correctamente.</p>
-          )}
-          {rutUploadStatus === 'error' && rutUploadError && (
-            <div className="flex items-center gap-2 text-xs text-red-600">
-              <AlertCircle size={14} />
-              <span>{rutUploadError}</span>
-            </div>
-          )}
-          {errors.rut && (
-            <div className="flex items-center gap-2 text-xs text-red-600">
-              <AlertCircle size={14} />
-              <span>{errors.rut}</span>
-            </div>
-          )}
+          <div id="rut-status" aria-live="polite">
+            {rutUploadStatus === 'uploading' && (
+              <p className="text-xs text-[#6A6A6A]">Subiendo documento...</p>
+            )}
+            {rutUploadStatus === 'success' && (
+              <p className="text-xs text-green-600">Documento cargado correctamente.</p>
+            )}
+            {rutUploadStatus === 'error' && rutUploadError && (
+              <div className="flex items-center gap-2 text-xs text-red-600">
+                <AlertCircle size={14} />
+                <span>{rutUploadError}</span>
+              </div>
+            )}
+            {errors.rut && (
+              <div className="flex items-center gap-2 text-xs text-red-600">
+                <AlertCircle size={14} />
+                <span>{errors.rut}</span>
+              </div>
+            )}
+          </div>
         </div>
 
-        <fieldset className="flex flex-col space-y-2">
+        <fieldset
+          className="flex flex-col space-y-2"
+          aria-describedby="electronic-invoicing-status"
+        >
           <legend className="text-sm font-medium text-[#1A1A1A] mb-1">
-            ¿Está obligado a emitir factura electrónica? <span className="text-red-500">*</span>
+            ¿Está obligado a emitir factura electrónica?{' '}
+            <span className="text-red-500" aria-hidden="true">*</span>
+            <span className="sr-only"> (obligatorio)</span>
           </legend>
-          <div className="flex gap-6">
+          <div className="flex gap-6" role="radiogroup" aria-required="true">
             <label className="flex items-center gap-2 text-sm text-[#1A1A1A] cursor-pointer">
               <input
                 type="radio"
@@ -128,22 +137,26 @@ export function RutCard({
               No
             </label>
           </div>
-          {errors.electronicInvoicingRequired && (
-            <div className="flex items-center gap-2 text-xs text-red-600">
-              <AlertCircle size={14} />
-              <span>{errors.electronicInvoicingRequired}</span>
-            </div>
-          )}
+          <div id="electronic-invoicing-status" aria-live="polite">
+            {errors.electronicInvoicingRequired && (
+              <div className="flex items-center gap-2 text-xs text-red-600">
+                <AlertCircle size={14} />
+                <span>{errors.electronicInvoicingRequired}</span>
+              </div>
+            )}
+          </div>
         </fieldset>
 
         {electronicInvoicingRequired === true && (
           <div className="flex flex-col space-y-2">
             <Label className="text-sm font-medium text-[#1A1A1A]">
-              Formato 1876 <span className="text-red-500">*</span>
+              Formato 1876 <span className="text-red-500" aria-hidden="true">*</span>
+              <span className="sr-only"> (obligatorio)</span>
             </Label>
             <FileUploadBox
               label="Carga el formato 1876"
               fileName={documents.form1876}
+              describedById="form1876-status"
               onUpload={async () => {
                 const { openFileDialog, validateFile, generateFileName } = await import('@/lib/utils/file-upload');
                 const file = await openFileDialog();
@@ -162,30 +175,35 @@ export function RutCard({
               }}
               disabled={form1876UploadStatus === 'uploading'}
             />
-            {form1876UploadStatus === 'uploading' && (
-              <p className="text-xs text-[#6A6A6A]">Subiendo documento...</p>
-            )}
-            {form1876UploadStatus === 'success' && (
-              <p className="text-xs text-green-600">Documento cargado correctamente.</p>
-            )}
-            {form1876UploadStatus === 'error' && form1876UploadError && (
-              <div className="flex items-center gap-2 text-xs text-red-600">
-                <AlertCircle size={14} />
-                <span>{form1876UploadError}</span>
-              </div>
-            )}
-            {errors.form1876 && (
-              <div className="flex items-center gap-2 text-xs text-red-600">
-                <AlertCircle size={14} />
-                <span>{errors.form1876}</span>
-              </div>
-            )}
+            <div id="form1876-status" aria-live="polite">
+              {form1876UploadStatus === 'uploading' && (
+                <p className="text-xs text-[#6A6A6A]">Subiendo documento...</p>
+              )}
+              {form1876UploadStatus === 'success' && (
+                <p className="text-xs text-green-600">Documento cargado correctamente.</p>
+              )}
+              {form1876UploadStatus === 'error' && form1876UploadError && (
+                <div className="flex items-center gap-2 text-xs text-red-600">
+                  <AlertCircle size={14} />
+                  <span>{form1876UploadError}</span>
+                </div>
+              )}
+              {errors.form1876 && (
+                <div className="flex items-center gap-2 text-xs text-red-600">
+                  <AlertCircle size={14} />
+                  <span>{errors.form1876}</span>
+                </div>
+              )}
+            </div>
           </div>
         )}
 
         {electronicInvoicingRequired === false && (
-          <div className="flex items-start gap-2 rounded-[14px] bg-[#F3F0F7] p-3 text-xs text-[#4B236A]">
-            <Info size={14} className="mt-0.5 flex-shrink-0" />
+          <div
+            className="flex items-start gap-2 rounded-[14px] bg-[#F3F0F7] p-3 text-xs text-[#4B236A]"
+            aria-live="polite"
+          >
+            <Info size={14} className="mt-0.5 flex-shrink-0" aria-hidden="true" />
             <span>
               Podrás operar en la plataforma sin este requisito, aunque esta información
               podrá ser solicitada posteriormente si cambia tu situación tributaria.

--- a/app/frontend/src/components/provider/ui/file-upload-box.tsx
+++ b/app/frontend/src/components/provider/ui/file-upload-box.tsx
@@ -7,6 +7,16 @@ interface FileUploadBoxProps {
   onUpload: () => void;
   onRemove: () => void;
   disabled?: boolean;
+  /** Documenta obligatoriedad en la API del componente; no emite aria-required (ver describedById). */
+  required?: boolean;
+  /**
+   * Id de la región de estado/error asociada a este campo (aria-describedby).
+   * FileUploadBox es un <button> que abre un diálogo de archivos, no un control de
+   * formulario (textbox/combobox) — aria-required no es un atributo válido sobre
+   * role=button (falla aria-allowed-attr en axe). La obligatoriedad y los errores se
+   * comunican vía el nombre accesible del campo (label con sr-only) y esta descripción.
+   */
+  describedById?: string;
 }
 
 export function FileUploadBox({
@@ -15,10 +25,11 @@ export function FileUploadBox({
   onUpload,
   onRemove,
   disabled = false,
+  describedById,
 }: FileUploadBoxProps) {
   return (
     <div className="flex items-center gap-3 p-4 bg-white rounded-[14px] border-2 border-[#4B236A]/20">
-      <FileText className="w-6 h-6 text-[#4B236A] flex-shrink-0" />
+      <FileText className="w-6 h-6 text-[#4B236A] flex-shrink-0" aria-hidden="true" />
       <div className="flex-1 min-w-0">
         <p className="text-sm text-gray-700">{label}</p>
         {fileName && (
@@ -34,9 +45,11 @@ export function FileUploadBox({
           size="sm"
           onClick={onRemove}
           disabled={disabled}
+          aria-describedby={describedById}
+          aria-label={`Eliminar ${fileName}`}
           className="text-red-600 hover:text-red-700 hover:bg-red-50 rounded-[14px] flex-shrink-0"
         >
-          <Trash2 className="w-4 h-4" />
+          <Trash2 className="w-4 h-4" aria-hidden="true" />
         </Button>
       ) : (
         <Button
@@ -44,9 +57,11 @@ export function FileUploadBox({
           size="sm"
           onClick={onUpload}
           disabled={disabled}
+          aria-describedby={describedById}
+          aria-label={label}
           className="bg-[#4B236A] hover:bg-[#4B236A]/90 text-white rounded-[14px] flex-shrink-0"
         >
-          <Upload className="w-4 h-4 mr-2" />
+          <Upload className="w-4 h-4 mr-2" aria-hidden="true" />
           Cargar
         </Button>
       )}


### PR DESCRIPTION
## Resumen

Corrige la accesibilidad (WCAG 2.1 AA) de `FileUploadBox` y de las cards de
documentos del proveedor (`RutCard`, `CamaraComercioCard`,
`RepresentanteLegalCard`), que no comunicaban a lectores de pantalla la
obligatoriedad de un campo, los mensajes de error, ni los cambios de estado
de carga (subiendo / éxito / error).

Jira: SCRUM-317

## Cambios

- **`FileUploadBox`**: nuevas props `describedById` y `required`;
  `aria-describedby` en ambos botones; `aria-label` explícito en el botón de
  carga (antes dependía solo de texto genérico repetido) y en el de
  eliminar (`Eliminar {fileName}`, antes sin nombre accesible por ser un
  ícono `Trash2` sin texto); íconos decorativos marcados `aria-hidden`.
- **`RutCard`, `CamaraComercioCard`, `RepresentanteLegalCard`**: patrón
  `sr-only "(obligatorio)"` en los labels de campos requeridos; región
  `aria-live="polite"` persistente en el DOM (no se monta/desmonta
  condicionalmente) que consolida estado de carga, éxito, error y error de
  validación de cada campo.
- **`RepresentanteLegalCard`** (alcance ampliado a pedido): se aplicó el
  mismo tratamiento a los 4 campos de texto/select (Nombres, Apellidos,
  Tipo de Documento, Número de Documento) — `aria-required`,
  `aria-invalid`, `aria-describedby` y región `aria-live` propia por campo.
- **`RutCard`** — corrección ARIA en el radiogroup de facturación
  electrónica: `aria-required="true"` movido del `role="radio"` individual
  (inválido, falla `role-supports-aria-props`) al contenedor
  `role="radiogroup"`; se agregó `aria-describedby` en el `fieldset` y
  `aria-live="polite"` en el mensaje informativo cuando se selecciona "No".

## Fuera de alcance

- Verificación real con lector de pantalla (NVDA/VoiceOver) — no disponible
  en este entorno. Se solicita a QA como parte de "Pruebas funcionales".

## Verificación

- `tsc --noEmit`: sin errores.
- `eslint` (incluye `eslint-plugin-jsx-a11y`) sobre los 4 archivos
  modificados: 0 errores, 0 warnings.
- Smoke test manual de la ruta `/provider/basic-info` (compila, sin 500).

## Checklist

- [x] Sin cambios de comportamiento funcional (solo atributos ARIA/DOM)
- [x] `tsc --noEmit` limpio
- [x] `eslint` limpio (jsx-a11y incluido)
- [ ] Verificación con lector de pantalla — pendiente en QA
