### PR TITLE
fix(auth): toggle de contraseña en formularios sin el (SCRUM-257)

### DIFF
--- a/app/frontend/src/components/admin/login-form.tsx
+++ b/app/frontend/src/components/admin/login-form.tsx
@@ -3,6 +3,7 @@
 import { FormEvent, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { Eye, EyeOff, Lock, Mail } from "lucide-react";
 import { login } from "@/lib/api/index";
 import type { SessionData } from "@/types/auth";
 import { persistSession } from "@/lib/session";
@@ -24,6 +25,7 @@ type LoginFormProps = {
 export function LoginForm({ onSubmit, labels }: LoginFormProps) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const router = useRouter();
@@ -78,7 +80,7 @@ export function LoginForm({ onSubmit, labels }: LoginFormProps) {
       <label className="block">
         <span className="block text-[var(--color-text)] mb-2">{labels.emailLabel}</span>
         <div className="relative">
-          <MailIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-[var(--color-brand)]" />
+          <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-[var(--color-brand)]" />
           <input
             required
             type="email"
@@ -92,22 +94,34 @@ export function LoginForm({ onSubmit, labels }: LoginFormProps) {
         </div>
       </label>
 
-      <label className="block">
-        <span className="block text-[var(--color-text)] mb-2">{labels.passwordLabel}</span>
+      <div className="block">
+        <label htmlFor="admin-login-password" className="block text-[var(--color-text)] mb-2">
+          {labels.passwordLabel}
+        </label>
         <div className="relative">
-          <LockIcon className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-[var(--color-brand)]" />
+          <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-[var(--color-brand)]" />
+          <button
+            type="button"
+            onClick={() => setShowPassword((prev) => !prev)}
+            disabled={loading}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 transition-colors hover:text-[var(--color-brand)] disabled:opacity-50"
+            aria-label={showPassword ? "Ocultar contraseña" : "Mostrar contraseña"}
+          >
+            {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+          </button>
           <input
+            id="admin-login-password"
             required
-            type="password"
+            type={showPassword ? "text" : "password"}
             name="password"
             autoComplete="current-password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             placeholder={labels.passwordPlaceholder}
-            className="w-full h-[50px] pl-11 pr-4 border border-[var(--color-border)] rounded-[14px] text-[#1A1A1A] placeholder:text-[#9CA3AF] focus:outline-none focus:ring-2 focus:ring-[var(--color-brand)] focus:border-transparent transition"
+            className="w-full h-[50px] pl-11 pr-10 border border-[var(--color-border)] rounded-[14px] text-[#1A1A1A] placeholder:text-[#9CA3AF] focus:outline-none focus:ring-2 focus:ring-[var(--color-brand)] focus:border-transparent transition"
           />
         </div>
-      </label>
+      </div>
 
       <div className="text-right">
         <Link
@@ -132,43 +146,5 @@ export function LoginForm({ onSubmit, labels }: LoginFormProps) {
         {loading ? `${labels.submit}...` : labels.submit}
       </button>
     </form>
-  );
-}
-
-function MailIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <path d="M4.75 5.75h14.5a1 1 0 0 1 1 1v10.5a1 1 0 0 1-1 1H4.75a1 1 0 0 1-1-1V6.75a1 1 0 0 1 1-1Z" />
-      <path d="m4 7 8 5 8-5" />
-    </svg>
-  );
-}
-
-function LockIcon({ className }: { className?: string }) {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      className={className}
-      aria-hidden="true"
-    >
-      <rect x="5.5" y="10.5" width="13" height="9" rx="2" />
-      <path d="M9 10.5V7.75a3 3 0 0 1 6 0v2.75" />
-    </svg>
   );
 }

--- a/app/frontend/src/components/admin/reset-password-form.tsx
+++ b/app/frontend/src/components/admin/reset-password-form.tsx
@@ -2,7 +2,7 @@
 
 import { FormEvent, useMemo, useState } from "react";
 import Link from "next/link";
-import { ArrowLeft, KeyRound, Lock, Mail } from "lucide-react";
+import { ArrowLeft, Eye, EyeOff, KeyRound, Lock, Mail } from "lucide-react";
 
 import { resetPassword } from "@/lib/api/auth";
 
@@ -19,6 +19,7 @@ export function AdminResetPasswordForm({
   const [token, setToken] = useState(initialToken);
   const [password, setPassword] = useState("");
   const [passwordConfirmation, setPasswordConfirmation] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
@@ -140,47 +141,71 @@ export function AdminResetPasswordForm({
         </div>
       </label>
 
-      <label className="block">
-        <span className="mb-2 block text-[var(--color-text)]">Nueva Contraseña</span>
+      <div className="block">
+        <label htmlFor="admin-reset-password" className="mb-2 block text-[var(--color-text)]">
+          Nueva Contraseña
+        </label>
         <div className="relative">
           <Lock className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-[var(--color-brand)]" />
+          <button
+            type="button"
+            onClick={() => setShowPassword((prev) => !prev)}
+            disabled={loading}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 transition-colors hover:text-[var(--color-brand)] disabled:opacity-50"
+            aria-label={showPassword ? "Ocultar contraseña" : "Mostrar contraseña"}
+          >
+            {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+          </button>
           <input
+            id="admin-reset-password"
             required
-            type="password"
+            type={showPassword ? "text" : "password"}
             name="password"
             autoComplete="new-password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             placeholder="••••••••"
             disabled={loading}
-            className={inputClassName}
+            className={`${inputClassName} pr-10`}
           />
         </div>
         {!isPasswordValid && password.length > 0 && (
           <p className="mt-1 text-xs text-red-600">Debe tener al menos 8 caracteres.</p>
         )}
-      </label>
+      </div>
 
-      <label className="block">
-        <span className="mb-2 block text-[var(--color-text)]">Confirmar Contraseña</span>
+      <div className="block">
+        <label htmlFor="admin-reset-password-confirmation" className="mb-2 block text-[var(--color-text)]">
+          Confirmar Contraseña
+        </label>
         <div className="relative">
           <Lock className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-[var(--color-brand)]" />
+          <button
+            type="button"
+            onClick={() => setShowPassword((prev) => !prev)}
+            disabled={loading}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 transition-colors hover:text-[var(--color-brand)] disabled:opacity-50"
+            aria-label={showPassword ? "Ocultar contraseña" : "Mostrar contraseña"}
+          >
+            {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+          </button>
           <input
+            id="admin-reset-password-confirmation"
             required
-            type="password"
+            type={showPassword ? "text" : "password"}
             name="password_confirmation"
             autoComplete="new-password"
             value={passwordConfirmation}
             onChange={(e) => setPasswordConfirmation(e.target.value)}
             placeholder="••••••••"
             disabled={loading}
-            className={inputClassName}
+            className={`${inputClassName} pr-10`}
           />
         </div>
         {passwordConfirmation.length > 0 && !passwordsMatch && (
           <p className="mt-1 text-xs text-red-600">Las contraseñas no coinciden.</p>
         )}
-      </label>
+      </div>
 
       {error ? (
         <div

--- a/app/frontend/src/components/app/auth/app-login-form.tsx
+++ b/app/frontend/src/components/app/auth/app-login-form.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Eye, EyeOff, Mail } from "lucide-react";
+import { Eye, EyeOff, Lock, Mail } from "lucide-react";
 
 import { useAppAuthForm } from "@/hooks/app/use-app-auth-form";
 import { Button } from "@/components/app/ui/button";
@@ -50,11 +50,12 @@ export default function AppLoginForm({ onForgotPassword }: AppLoginFormProps) {
       </div>
 
       <div className="relative">
+        <Lock className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-[#7A2E9A]" />
         <button
           type="button"
           onClick={() => setShowPassword((prev) => !prev)}
           disabled={loading}
-          className="absolute left-3 top-1/2 -translate-y-1/2 text-[#7A2E9A]"
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-[#7A2E9A] disabled:opacity-50"
           aria-label={showPassword ? "Ocultar contraseña" : "Mostrar contraseña"}
         >
           {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
@@ -64,7 +65,7 @@ export default function AppLoginForm({ onForgotPassword }: AppLoginFormProps) {
           placeholder="Contraseña"
           value={password}
           onChange={(event) => setPassword(event.target.value)}
-          className="h-12 rounded-xl border-[#E6E6E6] bg-white pl-10 focus:border-[#5A1E6B] focus:ring-[#5A1E6B]"
+          className="h-12 rounded-xl border-[#E6E6E6] bg-white pl-10 pr-10 focus:border-[#5A1E6B] focus:ring-[#5A1E6B]"
           aria-label="Contraseña"
           autoComplete="current-password"
           required

--- a/app/frontend/src/components/app/auth/app-register-form.tsx
+++ b/app/frontend/src/components/app/auth/app-register-form.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { Eye, EyeOff, Mail, User } from "lucide-react";
+import { Eye, EyeOff, Lock, Mail, User } from "lucide-react";
 
 import { useAppAuthForm } from "@/hooks/app/use-app-auth-form";
 import { PASSWORD_MIN_LENGTH, validatePasswordPolicy } from "@/lib/auth/password-policy";
@@ -78,11 +78,12 @@ export default function AppRegisterForm() {
         </div>
 
         <div className="relative">
+          <Lock className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-[#7A2E9A]" />
           <button
             type="button"
             onClick={() => setShowPassword((prev) => !prev)}
             disabled={loading}
-            className="absolute left-3 top-1/2 -translate-y-1/2 text-[#7A2E9A]"
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-[#7A2E9A] disabled:opacity-50"
             aria-label={showPassword ? "Ocultar contraseña" : "Mostrar contraseña"}
           >
             {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
@@ -92,7 +93,7 @@ export default function AppRegisterForm() {
             placeholder="Contraseña"
             value={password}
             onChange={(event) => setPassword(event.target.value)}
-            className={`h-12 rounded-xl bg-white pl-10 focus:ring-[#5A1E6B] ${
+            className={`h-12 rounded-xl bg-white pl-10 pr-10 focus:ring-[#5A1E6B] ${
               hasWeakPassword
                 ? "border-[#B9342D] focus:border-[#B9342D]"
                 : "border-[#E6E6E6] focus:border-[#5A1E6B]"
@@ -129,11 +130,12 @@ export default function AppRegisterForm() {
         </div>
 
         <div className="relative">
+          <Lock className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-[#7A2E9A]" />
           <button
             type="button"
             onClick={() => setShowPassword((prev) => !prev)}
             disabled={loading}
-            className="absolute left-3 top-1/2 -translate-y-1/2 text-[#7A2E9A]"
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-[#7A2E9A] disabled:opacity-50"
             aria-label={showPassword ? "Ocultar contrasena" : "Mostrar contrasena"}
           >
             {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
@@ -143,7 +145,7 @@ export default function AppRegisterForm() {
             placeholder="Repetir contrasena"
             value={confirmPassword}
             onChange={(event) => setConfirmPassword(event.target.value)}
-            className={`h-12 rounded-xl bg-white pl-10 focus:ring-[#5A1E6B] ${
+            className={`h-12 rounded-xl bg-white pl-10 pr-10 focus:ring-[#5A1E6B] ${
               hasPasswordMismatch
                 ? "border-[#B9342D] focus:border-[#B9342D]"
                 : "border-[#E6E6E6] focus:border-[#5A1E6B]"

--- a/app/frontend/src/components/app/auth/app-reset-password-form.tsx
+++ b/app/frontend/src/components/app/auth/app-reset-password-form.tsx
@@ -2,7 +2,7 @@
 
 import { FormEvent, useMemo, useState } from "react";
 import Link from "next/link";
-import { KeyRound, Lock, Mail } from "lucide-react";
+import { Eye, EyeOff, KeyRound, Lock, Mail } from "lucide-react";
 
 import { resetPassword } from "@/lib/api/auth";
 import { Button } from "@/components/app/ui/button";
@@ -21,6 +21,7 @@ export default function AppResetPasswordForm({
   const [token, setToken] = useState(initialToken);
   const [password, setPassword] = useState("");
   const [passwordConfirmation, setPasswordConfirmation] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
@@ -142,14 +143,23 @@ export default function AppResetPasswordForm({
         <div className="space-y-1">
           <div className="relative">
             <Lock className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-[#7A2E9A]" />
+            <button
+              type="button"
+              onClick={() => setShowPassword((prev) => !prev)}
+              disabled={loading}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 transition-colors hover:text-[#5A1E6B] disabled:opacity-50"
+              aria-label={showPassword ? "Ocultar contraseña" : "Mostrar contraseña"}
+            >
+              {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+            </button>
             <Input
               id="app-reset-password"
-              type="password"
+              type={showPassword ? "text" : "password"}
               placeholder="Nueva contraseña"
               value={password}
               onChange={(event) => setPassword(event.target.value)}
               disabled={loading}
-              className="h-12 rounded-xl border-[#E6E6E6] bg-white pl-10 focus:border-[#5A1E6B] focus:ring-[#5A1E6B]"
+              className="h-12 rounded-xl border-[#E6E6E6] bg-white pl-10 pr-10 focus:border-[#5A1E6B] focus:ring-[#5A1E6B]"
               aria-label="Nueva contraseña"
               autoComplete="new-password"
               required
@@ -163,14 +173,23 @@ export default function AppResetPasswordForm({
         <div className="space-y-1">
           <div className="relative">
             <Lock className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-[#7A2E9A]" />
+            <button
+              type="button"
+              onClick={() => setShowPassword((prev) => !prev)}
+              disabled={loading}
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 transition-colors hover:text-[#5A1E6B] disabled:opacity-50"
+              aria-label={showPassword ? "Ocultar contraseña" : "Mostrar contraseña"}
+            >
+              {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+            </button>
             <Input
               id="app-reset-password-confirmation"
-              type="password"
+              type={showPassword ? "text" : "password"}
               placeholder="Confirmar contraseña"
               value={passwordConfirmation}
               onChange={(event) => setPasswordConfirmation(event.target.value)}
               disabled={loading}
-              className="h-12 rounded-xl border-[#E6E6E6] bg-white pl-10 focus:border-[#5A1E6B] focus:ring-[#5A1E6B]"
+              className="h-12 rounded-xl border-[#E6E6E6] bg-white pl-10 pr-10 focus:border-[#5A1E6B] focus:ring-[#5A1E6B]"
               aria-label="Confirmar contraseña"
               autoComplete="new-password"
               required

--- a/app/frontend/src/components/provider/auth/reset-password-form.tsx
+++ b/app/frontend/src/components/provider/auth/reset-password-form.tsx
@@ -2,7 +2,7 @@
 
 import { FormEvent, useMemo, useState } from "react";
 import Link from "next/link";
-import { ArrowLeft, KeyRound, Lock, Mail } from "lucide-react";
+import { ArrowLeft, Eye, EyeOff, KeyRound, Lock, Mail } from "lucide-react";
 import { resetPassword } from "@/lib/api/auth";
 import { Button } from "@/components/provider/ui/button";
 import { Input } from "@/components/provider/ui/input";
@@ -19,6 +19,7 @@ export function ResetPasswordForm({ initialEmail = "", initialToken = "" }: Rese
   const [token, setToken] = useState(initialToken);
   const [password, setPassword] = useState("");
   const [passwordConfirmation, setPasswordConfirmation] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
@@ -155,14 +156,23 @@ export function ResetPasswordForm({ initialEmail = "", initialToken = "" }: Rese
         </Label>
         <div className="relative">
           <Lock className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-gray-400" />
+          <button
+            type="button"
+            onClick={() => setShowPassword((prev) => !prev)}
+            disabled={loading}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 transition-colors hover:text-[#4B236A] disabled:opacity-50"
+            aria-label={showPassword ? "Ocultar contraseña" : "Mostrar contraseña"}
+          >
+            {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+          </button>
           <Input
             id="reset-password"
-            type="password"
+            type={showPassword ? "text" : "password"}
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             disabled={loading}
             className={cn(
-              "pl-10 h-[50px] rounded-[14px] border-[#E0E0E0] placeholder-gray-400",
+              "pl-10 pr-10 h-[50px] rounded-[14px] border-[#E0E0E0] placeholder-gray-400",
               "focus:border-[#4B236A] focus:ring-2 focus:ring-[#4B236A]/20"
             )}
           />
@@ -178,14 +188,23 @@ export function ResetPasswordForm({ initialEmail = "", initialToken = "" }: Rese
         </Label>
         <div className="relative">
           <Lock className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-gray-400" />
+          <button
+            type="button"
+            onClick={() => setShowPassword((prev) => !prev)}
+            disabled={loading}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 transition-colors hover:text-[#4B236A] disabled:opacity-50"
+            aria-label={showPassword ? "Ocultar contraseña" : "Mostrar contraseña"}
+          >
+            {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+          </button>
           <Input
             id="reset-password-confirmation"
-            type="password"
+            type={showPassword ? "text" : "password"}
             value={passwordConfirmation}
             onChange={(e) => setPasswordConfirmation(e.target.value)}
             disabled={loading}
             className={cn(
-              "pl-10 h-[50px] rounded-[14px] border-[#E0E0E0] placeholder-gray-400",
+              "pl-10 pr-10 h-[50px] rounded-[14px] border-[#E0E0E0] placeholder-gray-400",
               "focus:border-[#4B236A] focus:ring-2 focus:ring-[#4B236A]/20"
             )}
           />


### PR DESCRIPTION
## Resumen
- Agrega el toggle de mostrar/ocultar contraseña en los 4 formularios que no lo tenían: login de admin, y reset-password de admin/app/provider.
- Estandariza el ícono a `Eye`/`EyeOff` de `lucide-react` en todos (elimina los SVG inline propios de `admin/login-form`).

## Hallazgos corregidos durante la verificación manual
- **/app (login y registro):** el botón de toggle estaba invertido a la izquierda sin ícono de candado; se agrega el candado y se mueve el botón a la derecha.
- **/admin (Firefox):** el toggle no respondía porque el botón estaba anidado dentro de un `<label>` que también asociaba el input (reenvío de clic inconsistente entre navegadores). Se desanida con `<label htmlFor>` + `id` explícito.

## Test plan
- [x] `tsc --noEmit` y `eslint` limpios en los 6 archivos
- [x] Verificado manualmente en Chrome y Firefox por el usuario (admin, app, provider)
- [ ] Retest de QA (Daniel Castro) en los 3 roles

Jira: SCRUM-257
EOF