### PR TITLE
feat(app): conectar catalogo real de la app movil (SCRUM-304, 290, 289)

### DIFF
--- a/app/backend/app/Http/Controllers/Api/V1/CatalogController.php
+++ b/app/backend/app/Http/Controllers/Api/V1/CatalogController.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Api\V1\CommerceBranchResource;
+use App\Http\Resources\Api\V1\ProductResource;
+use App\Services\CommerceBranchService;
+use App\Services\ProductService;
+use App\Traits\ApiResponseTrait;
+use Exception;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Response;
+
+/**
+ * Lectura pública de catálogo por id, para consumo de la app cliente.
+ *
+ * Distinto de los endpoints `products/{id}` y `commerce-branches/{id}`
+ * (apiResource protegidos, permisos provider.*): este controlador solo
+ * expone productos/sucursales activos, sin autenticación, en el mismo
+ * shape que los recursos de `nearby` para que el frontend reutilice
+ * un único set de tipos/adaptadores.
+ */
+class CatalogController extends Controller
+{
+    use ApiResponseTrait;
+
+    public function __construct(
+        private readonly ProductService $productService,
+        private readonly CommerceBranchService $commerceBranchService
+    ) {}
+
+    /** @OA.Get(
+     * path="/api/v1/catalog/products/{id}",
+     * summary="Get a single active product by id (public, customer app)",
+     * tags={"Catalog"},
+     *
+     * @OA.Parameter(name="id", in="path", required=true, @OA.Schema(type="integer", example=10)),
+     *
+     * @OA.Response(response=200, description="Product detail", @OA.JsonContent(@OA.Property(property="data", ref="#/components/schemas/ProductResource"))),
+     *
+     * @OA.Response(response=404, description="Product not found or not active"),
+     *
+     * @OA.Response(response=429, description="Too Many Requests")
+     * )
+     */
+    public function product(int $id): JsonResponse
+    {
+        try {
+            $product = $this->productService->showPublic($id);
+
+            return $this->successResponse(new ProductResource($product), 'Product retrieved successfully');
+        } catch (Exception $e) {
+            return $this->errorResponse('Product not found', Response::HTTP_NOT_FOUND);
+        }
+    }
+
+    /** @OA.Get(
+     * path="/api/v1/catalog/commerce-branches/{id}",
+     * summary="Get a single active commerce branch by id (public, customer app)",
+     * tags={"Catalog"},
+     *
+     * @OA.Parameter(name="id", in="path", required=true, @OA.Schema(type="integer", example=1)),
+     *
+     * @OA.Response(response=200, description="Commerce branch detail", @OA.JsonContent(@OA.Property(property="data", ref="#/components/schemas/CommerceBranchResource"))),
+     *
+     * @OA.Response(response=404, description="Branch not found or not active"),
+     *
+     * @OA.Response(response=429, description="Too Many Requests")
+     * )
+     */
+    public function branch(int $id): JsonResponse
+    {
+        try {
+            $branch = $this->commerceBranchService->showPublic($id);
+
+            return $this->successResponse(new CommerceBranchResource($branch), 'Commerce branch retrieved successfully');
+        } catch (Exception $e) {
+            return $this->errorResponse('Commerce branch not found', Response::HTTP_NOT_FOUND);
+        }
+    }
+}

--- a/app/backend/app/Http/Resources/Api/V1/CommerceBranchResource.php
+++ b/app/backend/app/Http/Resources/Api/V1/CommerceBranchResource.php
@@ -12,6 +12,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *
  *     @OA\Property(property="id", type="integer", example=1),
  *     @OA\Property(property="commerce_id", type="integer", example=5),
+ *     @OA\Property(property="commerce_name", type="string", nullable=true, example="Panaderia El Trigal", description="Nombre del proveedor propietario (solo si la relacion commerce esta cargada)"),
  *     @OA\Property(property="name", type="string", example="Sucursal Norte"),
  *     @OA\Property(property="address", type="string", example="Calle 123 #45-67"),
  *     @OA\Property(property="department", type="string", example="Cundinamarca"),
@@ -39,6 +40,7 @@ class CommerceBranchResource extends JsonResource
         return [
             'id' => $this->id,
             'commerce_id' => $this->commerce_id,
+            'commerce_name' => $this->whenLoaded('commerce', fn () => $this->commerce?->name),
             'photos' => $this->whenLoaded('commerceBranchPhotos', function () {
                 return $this->commerceBranchPhotos->map(function ($photo) {
                     return new DocumentUploadResource($photo, ['commerce_branch_id' => $this->id]);

--- a/app/backend/app/Http/Resources/Api/V1/NearbyBranchResource.php
+++ b/app/backend/app/Http/Resources/Api/V1/NearbyBranchResource.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace App\Http\Resources\Api\V1;
 
-use Illuminate\Http\Resources\Json\JsonResource;
-
 /**
  * @OA\Schema(
  *   schema="NearbyBranchResource",
@@ -21,7 +19,12 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *   @OA\Property(property="distance_km", type="number", format="float", example=2.35, description="Distancia en kilómetros desde la ubicación consultada"),
  * )
  */
-class NearbyBranchResource extends JsonResource
+/**
+ * Extiende CommerceBranchResource (no JsonResource) para heredar la
+ * serialización real de la sucursal (commerce_name, hours, department/city/
+ * neighborhood por nombre, photos) en vez de volcar el modelo Eloquent crudo.
+ */
+class NearbyBranchResource extends CommerceBranchResource
 {
     /**
      * Transform the resource into an array.

--- a/app/backend/app/Http/Resources/Api/V1/NearbyProductResource.php
+++ b/app/backend/app/Http/Resources/Api/V1/NearbyProductResource.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace App\Http\Resources\Api\V1;
 
-use Illuminate\Http\Resources\Json\JsonResource;
-
 /**
  * @OA\Schema(
  *   schema="NearbyProductResource",
@@ -21,7 +19,14 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *   @OA\Property(property="nearest_branch", ref="#/components/schemas/NearbyBranchResource", description="Sucursal más cercana con stock disponible"),
  * )
  */
-class NearbyProductResource extends JsonResource
+/**
+ * Extiende ProductResource (no JsonResource) para heredar la serialización
+ * real del producto (category, commerce_name, photos, etc.) en vez de volcar
+ * el modelo Eloquent crudo. Antes de este fix, `parent::toArray()` resolvía
+ * al JsonResource por defecto y devolvía `category`/`commerce` como modelos
+ * anidados sin filtrar (incluyendo deleted_at y otros campos internos).
+ */
+class NearbyProductResource extends ProductResource
 {
     /**
      * Transform the resource into an array.

--- a/app/backend/app/Http/Resources/Api/V1/ProductResource.php
+++ b/app/backend/app/Http/Resources/Api/V1/ProductResource.php
@@ -14,7 +14,9 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *
  *   @OA\Property(property="id", type="integer"),
  *   @OA\Property(property="commerce_id", type="integer"),
+ *   @OA\Property(property="commerce_name", type="string", nullable=true, description="Nombre del comercio propietario (solo si la relacion commerce esta cargada)"),
  *   @OA\Property(property="product_category_id", type="integer"),
+ *   @OA\Property(property="category", type="string", nullable=true, description="Nombre de la categoria (solo si la relacion category esta cargada)"),
  *   @OA\Property(property="title", type="string"),
  *   @OA\Property(property="description", type="string", nullable=true),
  *   @OA\Property(property="product_type", type="string", enum={"single","package"}),
@@ -59,7 +61,9 @@ class ProductResource extends JsonResource
         return [
             'id' => $this->id,
             'commerce_id' => $this->commerce_id,
+            'commerce_name' => $this->whenLoaded('commerce', fn () => $this->commerce?->name),
             'product_category_id' => $this->product_category_id,
+            'category' => $this->whenLoaded('category', fn () => $this->category?->name),
             'title' => $this->title,
             'description' => $this->description,
             'product_type' => $this->product_type,

--- a/app/backend/app/Services/CommerceBranchService.php
+++ b/app/backend/app/Services/CommerceBranchService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Constants\Constant;
 use App\Models\Commerce;
 use App\Models\CommerceBranch;
 use App\Models\CommerceBranchPhoto;
@@ -166,7 +167,19 @@ class CommerceBranchService
      */
     public function show(int $id): CommerceBranch
     {
-        return CommerceBranch::with(['department', 'city', 'neighborhood', 'commerceBranchHours', 'commerceBranchPhotos'])->findOrFail($id);
+        return CommerceBranch::with(['department', 'city', 'neighborhood', 'commerceBranchHours', 'commerceBranchPhotos', 'commerce'])->findOrFail($id);
+    }
+
+    /**
+     * Mostrar una sucursal para consumo público (app cliente).
+     * A diferencia de show(), solo expone sucursales activas: una sucursal
+     * inactiva no debe ser visible por id aunque se conozca el id.
+     */
+    public function showPublic(int $id): CommerceBranch
+    {
+        return CommerceBranch::with(['department', 'city', 'neighborhood', 'commerceBranchHours', 'commerceBranchPhotos', 'commerce'])
+            ->where('status', Constant::STATUS_ACTIVE)
+            ->findOrFail($id);
     }
 
     /**

--- a/app/backend/app/Services/NearbySearchService.php
+++ b/app/backend/app/Services/NearbySearchService.php
@@ -21,7 +21,7 @@ class NearbySearchService
         return CommerceBranch::query()
             ->nearby($lat, $lng, $radius)
             ->where('status', Constant::STATUS_ACTIVE)
-            ->with(['commerce', 'commerceBranchHours', 'commerceBranchPhotos'])
+            ->with(['commerce', 'commerceBranchHours', 'commerceBranchPhotos', 'department', 'city', 'neighborhood'])
             ->paginate($perPage);
     }
 
@@ -57,13 +57,16 @@ class NearbySearchService
             ->having('nearest_branch_distance_km', '<=', $radius)
             ->orderBy('nearest_branch_distance_km');
 
-        return $query->with(['photos', 'category', 'commerceBranches' => function ($q) use ($lat, $lng, $radius) {
+        return $query->with(['photos', 'category', 'commerce', 'commerceBranches' => function ($q) use ($lat, $lng, $radius) {
             // SQLite no soporta HAVING en subqueries sin agregación, así que usamos whereRaw
             $q->whereNotNull('latitude')
                 ->whereNotNull('longitude')
                 ->whereRaw('6371 * acos(cos(radians(?)) * cos(radians(latitude)) * cos(radians(longitude) - radians(?)) + sin(radians(?)) * sin(radians(latitude))) <= ?', [
                     $lat, $lng, $lat, $radius,
-                ]);
+                ])
+                // Necesario para que NearbyBranchResource (via CommerceBranchResource)
+                // sirva commerce_name y horarios de recogida sin N+1 por producto.
+                ->with(['commerce', 'commerceBranchHours', 'department', 'city', 'neighborhood']);
         }])->paginate($perPage);
     }
 }

--- a/app/backend/app/Services/ProductService.php
+++ b/app/backend/app/Services/ProductService.php
@@ -145,7 +145,19 @@ class ProductService
      */
     public function show(int $id): Product
     {
-        return Product::findOrFail($id);
+        return Product::with(['category', 'commerce'])->findOrFail($id);
+    }
+
+    /**
+     * Mostrar un producto para consumo público (app cliente).
+     * A diferencia de show(), solo expone productos activos: un producto
+     * inactivo/borrador no debe ser visible por id aunque se conozca el id.
+     */
+    public function showPublic(int $id): Product
+    {
+        return Product::with(['category', 'commerce', 'photos'])
+            ->where('status', Constant::STATUS_ACTIVE)
+            ->findOrFail($id);
     }
 
     /**

--- a/app/backend/routes/api.php
+++ b/app/backend/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Api\V1\AuditLogController;
 use App\Http\Controllers\Api\V1\AuthController;
 use App\Http\Controllers\Api\V1\BankController;
+use App\Http\Controllers\Api\V1\CatalogController;
 use App\Http\Controllers\Api\V1\CityController;
 use App\Http\Controllers\Api\V1\CommerceBasicDataController;
 use App\Http\Controllers\Api\V1\CommerceBranchController;
@@ -49,6 +50,15 @@ Route::prefix('v1')->group(function () {
     Route::prefix('nearby')->name('nearby.')->middleware('throttle:public-read')->group(function () {
         Route::get('branches', [NearbyController::class, 'branches']);
         Route::get('products', [NearbyController::class, 'products']);
+    });
+
+    // Catalog detail by id (público, throttle:public-read) — solo items activos.
+    // Distinto de nearby (búsqueda geográfica) y de products/commerce-branches
+    // (apiResource protegidos con permisos provider.*): esto es lectura pública
+    // puntual por id para la app cliente.
+    Route::prefix('catalog')->name('catalog.')->middleware('throttle:public-read')->group(function () {
+        Route::get('products/{id}', [CatalogController::class, 'product']);
+        Route::get('commerce-branches/{id}', [CatalogController::class, 'branch']);
     });
 
     // Protected routes (throttle:authenticated)

--- a/app/backend/tests/Feature/Api/V1/CatalogFeatureTest.php
+++ b/app/backend/tests/Feature/Api/V1/CatalogFeatureTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Constants\Constant;
+use App\Models\Commerce;
+use App\Models\CommerceBranch;
+use App\Models\Product;
+use App\Models\ProductCategory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CatalogFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_active_product_is_returned_with_category_name_and_commerce_name()
+    {
+        $commerce = Commerce::factory()->create(['name' => 'Panaderia El Trigal']);
+        $category = ProductCategory::factory()->create(['name' => 'Panaderia']);
+        $product = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'product_category_id' => $category->id,
+            'status' => Constant::STATUS_ACTIVE,
+            'description' => 'Bolsa sorpresa con pan del dia',
+        ]);
+
+        $response = $this->getJson("/api/v1/catalog/products/{$product->id}");
+
+        $response->assertOk();
+        // Commerce::sanitizeText normaliza el nombre a "lower + ucfirst" (comportamiento existente del modelo).
+        $response->assertJsonFragment([
+            'id' => $product->id,
+            'category' => 'Panaderia',
+            'commerce_name' => 'Panaderia el trigal',
+            'description' => 'Bolsa sorpresa con pan del dia',
+        ]);
+    }
+
+    public function test_inactive_product_is_not_visible_by_id()
+    {
+        $product = Product::factory()->create(['status' => Constant::STATUS_INACTIVE]);
+
+        $response = $this->getJson("/api/v1/catalog/products/{$product->id}");
+
+        $response->assertNotFound();
+    }
+
+    public function test_nonexistent_product_returns_404()
+    {
+        $response = $this->getJson('/api/v1/catalog/products/999999');
+
+        $response->assertNotFound();
+    }
+
+    public function test_active_branch_is_returned_with_commerce_name()
+    {
+        $commerce = Commerce::factory()->create(['name' => 'Cafe Amor Perfecto']);
+        $branch = CommerceBranch::factory()->create([
+            'commerce_id' => $commerce->id,
+            'status' => Constant::STATUS_ACTIVE,
+        ]);
+
+        $response = $this->getJson("/api/v1/catalog/commerce-branches/{$branch->id}");
+
+        $response->assertOk();
+        $response->assertJsonFragment([
+            'id' => $branch->id,
+            'commerce_name' => 'Cafe amor perfecto',
+        ]);
+    }
+
+    public function test_inactive_branch_is_not_visible_by_id()
+    {
+        $branch = CommerceBranch::factory()->create(['status' => Constant::STATUS_INACTIVE]);
+
+        $response = $this->getJson("/api/v1/catalog/commerce-branches/{$branch->id}");
+
+        $response->assertNotFound();
+    }
+
+    public function test_nonexistent_branch_returns_404()
+    {
+        $response = $this->getJson('/api/v1/catalog/commerce-branches/999999');
+
+        $response->assertNotFound();
+    }
+
+    public function test_catalog_endpoints_do_not_require_authentication()
+    {
+        $product = Product::factory()->create(['status' => Constant::STATUS_ACTIVE]);
+        $branch = CommerceBranch::factory()->create(['status' => Constant::STATUS_ACTIVE]);
+
+        $this->getJson("/api/v1/catalog/products/{$product->id}")->assertOk();
+        $this->getJson("/api/v1/catalog/commerce-branches/{$branch->id}")->assertOk();
+    }
+}

--- a/app/backend/tests/Feature/Api/V1/NearbyFeatureTest.php
+++ b/app/backend/tests/Feature/Api/V1/NearbyFeatureTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Tests\Feature\Api\V1;
 
 use App\Constants\Constant;
+use App\Models\Commerce;
 use App\Models\CommerceBranch;
+use App\Models\CommerceBranchHour;
 use App\Models\Product;
 use App\Models\ProductCategory;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -114,6 +116,57 @@ class NearbyFeatureTest extends TestCase
     {
         $response = $this->getJson('/api/v1/nearby/branches?latitude=200&longitude=10&radius=10');
         $response->assertStatus(422);
+    }
+
+    public function test_product_category_is_a_flat_name_not_a_nested_model()
+    {
+        // Regresión: NearbyProductResource extendía JsonResource en vez de
+        // ProductResource, así que category llegaba como el modelo crudo
+        // ({"id":..,"name":..,"deleted_at":..}) en vez del nombre plano.
+        $commerce = Commerce::factory()->create(['name' => 'Panaderia El Trigal']);
+        $category = ProductCategory::factory()->create(['name' => 'Panaderia']);
+        $branch = CommerceBranch::factory()->create(['commerce_id' => $commerce->id, 'latitude' => 10, 'longitude' => 10]);
+        $product = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'product_category_id' => $category->id,
+            'status' => Constant::STATUS_ACTIVE,
+            'quantity_available' => 5,
+            'expires_at' => now()->addDay(),
+        ]);
+        $product->commerceBranches()->attach($branch->id);
+
+        $response = $this->getJson('/api/v1/nearby/products?latitude=10&longitude=10&radius=10');
+
+        $response->assertOk();
+        $response->assertJsonFragment(['category' => 'Panaderia', 'commerce_name' => 'Panaderia el trigal']);
+    }
+
+    public function test_nearest_branch_includes_commerce_name_and_pickup_hours()
+    {
+        $commerce = Commerce::factory()->create(['name' => 'Cafe Amor Perfecto']);
+        $branch = CommerceBranch::factory()->create(['commerce_id' => $commerce->id, 'latitude' => 10, 'longitude' => 10]);
+        CommerceBranchHour::factory()->create([
+            'commerce_branch_id' => $branch->id,
+            'day_of_week' => 1,
+            'open_time' => '08:00:00',
+            'close_time' => '18:00:00',
+        ]);
+        $product = Product::factory()->create([
+            'commerce_id' => $commerce->id,
+            'status' => Constant::STATUS_ACTIVE,
+            'quantity_available' => 5,
+            'expires_at' => now()->addDay(),
+        ]);
+        $product->commerceBranches()->attach($branch->id);
+
+        $response = $this->getJson('/api/v1/nearby/products?latitude=10&longitude=10&radius=10');
+
+        $response->assertOk();
+        $data = $response->json('data.0');
+        $this->assertSame('Cafe amor perfecto', $data['nearest_branch']['commerce_name']);
+        $this->assertNotEmpty($data['nearest_branch']['hours']);
+        $this->assertSame('08:00:00', $data['nearest_branch']['hours'][0]['open_time']);
+        $this->assertSame('18:00:00', $data['nearest_branch']['hours'][0]['close_time']);
     }
 
     public function test_pagination_works()

--- a/app/frontend/src/app/app/(protected)/discover/page.tsx
+++ b/app/frontend/src/app/app/(protected)/discover/page.tsx
@@ -4,7 +4,7 @@ import dynamic from "next/dynamic";
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { Bell, Clock3, MapPin, Star } from "lucide-react";
+import { Bell, Clock3, MapPin } from "lucide-react";
 import { LocationStatusBanner } from "@/components/shared/location-status-banner";
 import { useUserLocation } from "@/hooks/use-user-location";
 import { getNearbyProducts } from "@/lib/api/app-catalog";
@@ -117,7 +117,6 @@ export default function AppDiscoverPage() {
   };
 
   const hasMorePages = currentPage < lastPage;
-  const DUMMY_SCHEDULE_LABEL = "Horario referencial (dummy): Hoy 18:00 - 20:00";
 
   const getDiscountPercentage = (price: number, originalPrice: number): number => {
     if (originalPrice <= 0 || originalPrice <= price) {
@@ -126,28 +125,10 @@ export default function AppDiscoverPage() {
 
     return Math.round(((originalPrice - price) / originalPrice) * 100);
   };
-  
-  const buildProductHref = (card: DiscoverNearbyCard): string => {
-    const params = new URLSearchParams({
-      source: "discover",
-      name: card.name,
-      category: card.category,
-      address: card.address,
-      price: String(card.price),
-      originalPrice: String(card.originalPrice),
-      available: String(card.available),
-      pickupTime: DUMMY_SCHEDULE_LABEL,
-      deliveryTime: DUMMY_SCHEDULE_LABEL,
-      deliveryCost: String(card.deliveryCost),
-      description: card.description,
-    });
 
-    if (card.imageUrl) {
-      params.set("imageUrl", card.imageUrl);
-    }
-
-    return `/app/product/${card.productId}?${params.toString()}`;
-  };
+  // El detalle de producto obtiene sus propios datos por id (GET /catalog/products/{id});
+  // ya no se transportan datos por query params.
+  const buildProductHref = (card: DiscoverNearbyCard): string => `/app/product/${card.productId}`;
 
   const handleLoadMore = async () => {
     if (!location || state !== "ready" || isLoadingMore || !hasMorePages) {
@@ -371,15 +352,10 @@ export default function AppDiscoverPage() {
                     </div>
 
                     <div className="p-4">
-                      <div className="mb-2 flex items-start justify-between gap-3">
-                        <div className="min-w-0">
-                          <h3 className="truncate text-base text-[var(--color-app-text-dark)]">{card.name}</h3>
-                          <p className="truncate text-sm text-[var(--color-app-text-secondary-purple)]">{card.category}</p>
-                        </div>
-                        <span className="inline-flex shrink-0 items-center gap-1 rounded-lg bg-[var(--color-app-tomatillo-soft)] px-2 py-1 text-sm text-[var(--color-app-text-dark)]">
-                          <Star className="h-3.5 w-3.5 fill-[#95af51] text-[#95af51]" />
-                          {card.rating.toFixed(1)}
-                        </span>
+                      {/* Sin badge de rating: no existe modelo de reseñas aún (SCRUM-350, post-MVP) */}
+                      <div className="mb-2 min-w-0">
+                        <h3 className="truncate text-base text-[var(--color-app-text-dark)]">{card.name}</h3>
+                        <p className="truncate text-sm text-[var(--color-app-text-secondary-purple)]">{card.category}</p>
                       </div>
 
                       <p className="truncate text-xs text-[var(--color-app-text-secondary-purple)]">{card.address}</p>
@@ -398,11 +374,12 @@ export default function AppDiscoverPage() {
                           <p className="text-sm text-[var(--color-app-text-primary-purple)]">
                             {card.available} {card.available === 1 ? "disponible" : "disponibles"}
                           </p>
-                          <p className="mt-1 inline-flex items-center gap-1 text-xs text-[var(--color-app-text-secondary-purple)]">
-                            <Clock3 className="h-3.5 w-3.5" />
-                            Hoy 18:00 - 20:00
-                            Horario referencial (dummy)
-                          </p>
+                          {card.pickupSchedule && (
+                            <p className="mt-1 inline-flex items-center gap-1 text-xs text-[var(--color-app-text-secondary-purple)]">
+                              <Clock3 className="h-3.5 w-3.5" />
+                              {card.pickupSchedule}
+                            </p>
+                          )}
                         </div>
                       </div>
                     </div>

--- a/app/frontend/src/app/app/(protected)/product/[storeId]/page.tsx
+++ b/app/frontend/src/app/app/(protected)/product/[storeId]/page.tsx
@@ -1,195 +1,132 @@
 import Link from "next/link";
-import { ArrowLeft, Plus, Store, Truck } from "lucide-react";
-import { getStoreById } from "@/lib/app/mock-catalog";
+import { AlertCircle, ArrowLeft, Plus } from "lucide-react";
+import { ApiError } from "@/lib/api/client";
+import { getProductDetail } from "@/lib/api/app-catalog";
+import { mapProductDetailToView, type ProductDetailView } from "@/types/app-catalog.adapters";
 
 type ProductDetailPageProps = {
   params: Promise<{ storeId: string }>;
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
-
-type ProductDetailView = {
-  id: number;
-  name: string;
-  category: string;
-  address: string;
-  price: number;
-  originalPrice: number;
-  available: number;
-  pickupTime: string;
-  deliveryTime: string;
-  deliveryCost: number;
-  description: string;
-  source: "discover" | "default";
-};
-
-function firstParam(value: string | string[] | undefined): string | undefined {
-  if (Array.isArray(value)) {
-    return value[0];
-  }
-
-  return value;
-}
-
-function toNumber(value: string | undefined, fallback: number): number {
-  if (!value) {
-    return fallback;
-  }
-
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : fallback;
-}
-
-function toText(value: string | undefined, fallback: string): string {
-  if (!value) {
-    return fallback;
-  }
-
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : fallback;
-}
-
-function buildProductFromSearchParams(
-  searchParams: Record<string, string | string[] | undefined>,
-  productId: number
-): ProductDetailView | null {
-  const source = firstParam(searchParams.source);
-  if (source !== "discover") {
-    return null;
-  }
-
-  return {
-    id: productId,
-    name: toText(firstParam(searchParams.name), "Producto cercano"),
-    category: toText(firstParam(searchParams.category), "Sin categoria"),
-    address: toText(firstParam(searchParams.address), "Ubicacion no disponible"),
-    price: toNumber(firstParam(searchParams.price), 0),
-    originalPrice: toNumber(firstParam(searchParams.originalPrice), toNumber(firstParam(searchParams.price), 0)),
-    available: toNumber(firstParam(searchParams.available), 1),
-    pickupTime: toText(firstParam(searchParams.pickupTime), "Consultar con el comercio"),
-    deliveryTime: toText(firstParam(searchParams.deliveryTime), "Consultar disponibilidad"),
-    deliveryCost: toNumber(firstParam(searchParams.deliveryCost), 0),
-    description: toText(firstParam(searchParams.description), "Producto cercano segun tu ubicacion."),
-    source: "discover",
-  };
-}
 
 function formatPrice(value: number): string {
   return `$${value.toLocaleString("es-CO")}`;
 }
 
-function buildCartHref(product: ProductDetailView, storeId: number): string {
+function buildCartHref(product: ProductDetailView): string {
   const params = new URLSearchParams({
     source: "product-detail",
-    storeId: String(storeId),
     productId: String(product.id),
-    name: product.name,
+    name: product.title,
     category: product.category,
-    address: product.address,
     price: String(product.price),
     originalPrice: String(product.originalPrice),
-    available: String(product.available),
-    pickupTime: product.pickupTime,
-    deliveryTime: product.deliveryTime,
-    deliveryCost: String(product.deliveryCost),
+    available: String(product.quantityAvailable),
     description: product.description,
   });
 
   return `/app/cart?${params.toString()}`;
 }
 
-export default async function ProductDetailPage({ params, searchParams }: ProductDetailPageProps) {
+function NotFoundState() {
+  return (
+    <section className="flex min-h-[60vh] flex-col items-center justify-center gap-3 px-4 text-center">
+      <AlertCircle className="h-8 w-8 text-[var(--color-app-text-secondary-purple)]" />
+      <h1 className="text-lg text-[var(--color-app-text-dark)]">Producto no encontrado</h1>
+      <p className="text-sm text-[var(--color-app-text-secondary-purple)]">
+        Puede que ya no esté disponible o el enlace sea incorrecto.
+      </p>
+      <Link
+        href="/app/discover"
+        className="mt-2 inline-flex h-9 items-center rounded-xl border border-[var(--color-app-ui-divider)] px-3 text-xs text-[var(--color-app-text-primary-purple)] transition hover:bg-[var(--color-app-ui-background-soft)]"
+      >
+        Volver a Descubre
+      </Link>
+    </section>
+  );
+}
+
+function ErrorState() {
+  return (
+    <section className="flex min-h-[60vh] flex-col items-center justify-center gap-3 px-4 text-center">
+      <AlertCircle className="h-8 w-8 text-[var(--color-app-text-secondary-purple)]" />
+      <p className="text-sm text-[var(--color-app-text-secondary-purple)]">
+        No se pudo cargar el producto en este momento. Intenta de nuevo.
+      </p>
+    </section>
+  );
+}
+
+export default async function ProductDetailPage({ params }: ProductDetailPageProps) {
   const { storeId } = await params;
-  const resolvedSearchParams = await searchParams;
-  const parsedStoreId = Number.parseInt(storeId, 10);
+  const productId = Number.parseInt(storeId, 10);
 
-  const safeStoreId = Number.isNaN(parsedStoreId) ? 1 : parsedStoreId;
-  const fallbackStore = getStoreById(safeStoreId) ?? getStoreById(1);
-  const productFromQuery = buildProductFromSearchParams(resolvedSearchParams, safeStoreId);
-
-  const product: ProductDetailView | null = productFromQuery
-    ?? (fallbackStore
-      ? {
-          id: fallbackStore.id,
-          name: fallbackStore.name,
-          category: fallbackStore.category,
-          address: fallbackStore.address,
-          price: fallbackStore.price,
-          originalPrice: fallbackStore.originalPrice,
-          available: fallbackStore.available,
-          pickupTime: fallbackStore.pickupTime,
-          deliveryTime: fallbackStore.deliveryTime,
-          deliveryCost: fallbackStore.deliveryCost,
-          description: fallbackStore.description,
-          source: "default",
-        }
-      : null);
-
-  if (!product) {
-    return null;
+  if (!Number.isInteger(productId) || productId <= 0) {
+    return <NotFoundState />;
   }
 
-  const discount = Math.round(((product.originalPrice - product.price) / product.originalPrice) * 100);
-  const backHref = product.source === "discover" ? "/app/discover" : `/app/store/${product.id}`;
-  const cartStoreId = fallbackStore?.id ?? 1;
+  let product: ProductDetailView;
+
+  try {
+    const response = await getProductDetail(productId);
+    product = mapProductDetailToView(response.data);
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) {
+      return <NotFoundState />;
+    }
+
+    return <ErrorState />;
+  }
+
+  const discount =
+    product.originalPrice > product.price
+      ? Math.round(((product.originalPrice - product.price) / product.originalPrice) * 100)
+      : 0;
 
   return (
     <section className="pb-6">
       <div className="relative h-56 bg-gradient-to-br from-[var(--color-app-tomatillo-soft)] via-white to-[var(--color-app-ui-background-soft)] px-4 pt-4">
         <Link
-          href={backHref}
+          href="/app/discover"
           className="app-btn-icon app-header-back-button bg-white/90 text-[var(--color-app-text-dark)] shadow-[var(--app-shadow-button)]"
-          aria-label="Volver a tienda"
+          aria-label="Volver a Descubre"
         >
           <ArrowLeft className="h-5 w-5" />
         </Link>
 
-        <div className="absolute right-4 top-4 rounded-full bg-[var(--color-app-text-primary-purple)] px-3 py-1 text-xs text-white">
-          -{discount}%
-        </div>
+        {discount > 0 && (
+          <div className="absolute right-4 top-4 rounded-full bg-[var(--color-app-text-primary-purple)] px-3 py-1 text-xs text-white">
+            -{discount}%
+          </div>
+        )}
 
         <div className="absolute bottom-4 left-4 rounded-full bg-white px-3 py-1 text-xs text-[var(--color-app-text-secondary-purple)]">
-          Quedan {product.available} disponibles
+          Quedan {product.quantityAvailable} disponibles
         </div>
       </div>
 
       <div className="space-y-4 px-4 pt-4">
         <header className="app-page-header p-4">
-          <h1 className="text-xl text-[var(--color-app-text-dark)]">Bolsa sorpresa de {product.category.toLowerCase()}</h1>
-          <p className="text-sm text-[var(--color-app-text-secondary-purple)]">{product.name}</p>
+          <h1 className="text-xl text-[var(--color-app-text-dark)]">{product.title}</h1>
+          <p className="text-sm text-[var(--color-app-text-secondary-purple)]">
+            {product.category} · {product.commerceName}
+          </p>
         </header>
 
         <div className="app-surface p-4">
           <div className="flex items-end gap-2">
             <p className="text-3xl text-[var(--color-app-tomatillo-medium)]">{formatPrice(product.price)}</p>
-            <p className="text-sm text-[var(--color-app-text-secondary-purple)] line-through">
-              {formatPrice(product.originalPrice)}
-            </p>
+            {product.originalPrice > product.price && (
+              <p className="text-sm text-[var(--color-app-text-secondary-purple)] line-through">
+                {formatPrice(product.originalPrice)}
+              </p>
+            )}
           </div>
           <p className="mt-1 text-sm text-[var(--color-app-text-secondary-purple)]">Por bolsa</p>
         </div>
 
         <div className="app-surface p-4">
-          <h2 className="text-base text-[var(--color-app-text-dark)]">Metodo de entrega</h2>
-
-          <div className="mt-3 space-y-2">
-            <div className="flex items-start gap-3 rounded-xl border border-[var(--color-app-ui-divider)] p-3">
-              <Store className="mt-0.5 h-4 w-4 text-[var(--color-app-text-primary-purple)]" />
-              <div>
-                <p className="text-sm text-[var(--color-app-text-dark)]">Recoger en tienda</p>
-                <p className="text-xs text-[var(--color-app-text-secondary-purple)]">{product.pickupTime}</p>
-              </div>
-            </div>
-
-            <div className="flex items-start gap-3 rounded-xl border border-[var(--color-app-ui-divider)] p-3">
-              <Truck className="mt-0.5 h-4 w-4 text-[var(--color-app-text-primary-purple)]" />
-              <div>
-                <p className="text-sm text-[var(--color-app-text-dark)]">Envio a domicilio</p>
-                <p className="text-xs text-[var(--color-app-text-secondary-purple)]">
-                  {product.deliveryTime} · {formatPrice(product.deliveryCost)}
-                </p>
-              </div>
-            </div>
-          </div>
+          <h2 className="text-base text-[var(--color-app-text-dark)]">Descripción</h2>
+          <p className="mt-2 text-sm text-[var(--color-app-text-secondary-purple)]">{product.description}</p>
         </div>
 
         <div className="app-surface p-4">
@@ -199,10 +136,7 @@ export default async function ProductDetailPage({ params, searchParams }: Produc
               <p className="text-2xl text-[var(--color-app-text-dark)]">{formatPrice(product.price)}</p>
             </div>
 
-            <Link
-              href={buildCartHref(product, cartStoreId)}
-              className="app-btn-primary gap-2"
-            >
+            <Link href={buildCartHref(product)} className="app-btn-primary gap-2">
               <Plus className="h-4 w-4" />
               Agregar al carrito
             </Link>

--- a/app/frontend/src/app/app/(protected)/store/[storeId]/page.tsx
+++ b/app/frontend/src/app/app/(protected)/store/[storeId]/page.tsx
@@ -1,30 +1,62 @@
 import Link from "next/link";
-import { notFound } from "next/navigation";
-import { ArrowLeft, Clock, Info, MapPin, Star } from "lucide-react";
-import { getStoreById } from "@/lib/app/mock-catalog";
+import { AlertCircle, ArrowLeft, Clock, MapPin } from "lucide-react";
+import { ApiError } from "@/lib/api/client";
+import { getBranchDetail } from "@/lib/api/app-catalog";
+import { mapBranchDetailToView, type BranchDetailView } from "@/types/app-catalog.adapters";
 
 type StoreDetailPageProps = {
   params: Promise<{ storeId: string }>;
 };
 
-function formatPrice(value: number): string {
-  return `$${value.toLocaleString("es-CO")}`;
+function NotFoundState() {
+  return (
+    <section className="flex min-h-[60vh] flex-col items-center justify-center gap-3 px-4 text-center">
+      <AlertCircle className="h-8 w-8 text-[var(--color-app-text-secondary-purple)]" />
+      <h1 className="text-lg text-[var(--color-app-text-dark)]">Tienda no encontrada</h1>
+      <p className="text-sm text-[var(--color-app-text-secondary-purple)]">
+        Puede que ya no esté disponible o el enlace sea incorrecto.
+      </p>
+      <Link
+        href="/app/discover"
+        className="mt-2 inline-flex h-9 items-center rounded-xl border border-[var(--color-app-ui-divider)] px-3 text-xs text-[var(--color-app-text-primary-purple)] transition hover:bg-[var(--color-app-ui-background-soft)]"
+      >
+        Volver a Descubre
+      </Link>
+    </section>
+  );
+}
+
+function ErrorState() {
+  return (
+    <section className="flex min-h-[60vh] flex-col items-center justify-center gap-3 px-4 text-center">
+      <AlertCircle className="h-8 w-8 text-[var(--color-app-text-secondary-purple)]" />
+      <p className="text-sm text-[var(--color-app-text-secondary-purple)]">
+        No se pudo cargar la tienda en este momento. Intenta de nuevo.
+      </p>
+    </section>
+  );
 }
 
 export default async function StoreDetailPage({ params }: StoreDetailPageProps) {
   const { storeId } = await params;
-  const parsedStoreId = Number.parseInt(storeId, 10);
+  const branchId = Number.parseInt(storeId, 10);
 
-  if (Number.isNaN(parsedStoreId)) {
-    notFound();
+  if (!Number.isInteger(branchId) || branchId <= 0) {
+    return <NotFoundState />;
   }
 
-  const store = getStoreById(parsedStoreId);
-  if (!store) {
-    notFound();
-  }
+  let store: BranchDetailView;
 
-  const savings = store.originalPrice - store.price;
+  try {
+    const response = await getBranchDetail(branchId);
+    store = mapBranchDetailToView(response.data);
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) {
+      return <NotFoundState />;
+    }
+
+    return <ErrorState />;
+  }
 
   return (
     <section className="pb-6">
@@ -36,18 +68,13 @@ export default async function StoreDetailPage({ params }: StoreDetailPageProps) 
         >
           <ArrowLeft className="h-5 w-5" />
         </Link>
-
-        <div className="absolute bottom-4 right-4 flex items-center gap-1 rounded-full bg-white px-3 py-1 text-xs text-[var(--color-app-text-dark)]">
-          <Star className="h-3.5 w-3.5 fill-[#F59E0B] text-[#F59E0B]" />
-          <span>{store.rating}</span>
-          <span className="text-[var(--color-app-text-secondary-purple)]">({store.reviews})</span>
-        </div>
       </div>
 
       <div className="space-y-4 px-4 pt-4">
         <header className="app-page-header p-4">
-          <h1 className="text-xl text-[var(--color-app-text-dark)]">{store.name}</h1>
-          <p className="text-sm text-[var(--color-app-text-secondary-purple)]">{store.category}</p>
+          {/* Nombre real del proveedor (SCRUM-289) como encabezado principal */}
+          <h1 className="text-xl text-[var(--color-app-text-dark)]">{store.commerceName}</h1>
+          <p className="text-sm text-[var(--color-app-text-secondary-purple)]">{store.branchName}</p>
         </header>
 
         <div className="app-surface p-4">
@@ -58,45 +85,27 @@ export default async function StoreDetailPage({ params }: StoreDetailPageProps) 
             </div>
             <div className="flex items-start gap-2">
               <Clock className="mt-0.5 h-4 w-4 text-[var(--color-app-text-primary-purple)]" />
-              <span>{store.pickupTime}</span>
-            </div>
-          </div>
-
-          <div className="mt-4 rounded-xl bg-[var(--color-app-tomatillo-soft)] p-3 text-sm text-[var(--color-app-text-primary-purple)]">
-            <div className="flex items-start gap-2">
-              <Info className="mt-0.5 h-4 w-4" />
-              <p>
-                Recoge antes del cierre. Quedan <strong>{store.available}</strong> bolsas disponibles.
-              </p>
+              <span>{store.scheduleLabel}</span>
             </div>
           </div>
         </div>
 
-        <div className="app-surface p-4">
-          <h2 className="text-base text-[var(--color-app-text-dark)]">Que incluye</h2>
-          <p className="mt-2 text-sm text-[var(--color-app-text-secondary-purple)]">{store.description}</p>
-        </div>
+        {/*
+          Sin sección de rating/reviews: no existe modelo de reseñas aún
+          (SCRUM-350, post-MVP). Se omite en vez de fabricar un valor.
+        */}
 
         <div className="app-surface p-4">
-          <div className="flex items-end justify-between gap-4">
-            <div>
-              <p className="text-sm text-[var(--color-app-text-secondary-purple)]">Precio</p>
-              <div className="mt-1 flex items-end gap-2">
-                <p className="text-2xl text-[var(--color-app-text-primary-purple)]">{formatPrice(store.price)}</p>
-                <p className="text-sm text-[var(--color-app-text-secondary-purple)] line-through">
-                  {formatPrice(store.originalPrice)}
-                </p>
-              </div>
-              <p className="text-xs text-[var(--color-app-status-success)]">Ahorras {formatPrice(savings)}</p>
-            </div>
-
-            <Link
-              href={`/app/product/${store.id}`}
-              className="app-btn-primary"
-            >
-              Rescatar ahora
-            </Link>
-          </div>
+          {/*
+            No enlaza a un producto específico: el id de esta página es de
+            sucursal, no de producto (namespaces distintos en datos reales,
+            a diferencia del mock donde coincidían). Listar los productos
+            de esta sucursal es una funcionalidad nueva, fuera de alcance
+            de esta fase (discover no filtra por sucursal hoy).
+          */}
+          <Link href="/app/discover" className="app-btn-primary flex items-center justify-center">
+            Ver más cerca de ti
+          </Link>
         </div>
       </div>
     </section>

--- a/app/frontend/src/lib/api/app-catalog.ts
+++ b/app/frontend/src/lib/api/app-catalog.ts
@@ -1,5 +1,16 @@
 import { ApiError, fetchWithErrorHandling } from "./client";
-import type { NearbyProductsParams, NearbyProductsResponse } from "@/types/app-catalog";
+import type {
+  BranchDetailResponse,
+  NearbyProductsParams,
+  NearbyProductsResponse,
+  ProductDetailResponse,
+} from "@/types/app-catalog";
+
+function ensureValidId(id: number, label: string): void {
+  if (!Number.isInteger(id) || id <= 0) {
+    throw new ApiError(`${label} inválido.`, 422);
+  }
+}
 
 function ensureValidCoordinates(latitude: number, longitude: number): void {
   if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) {
@@ -53,4 +64,28 @@ export async function getNearbyProducts(
       method: "GET",
     }
   );
+}
+
+/**
+ * GET /api/v1/catalog/products/{id}
+ * Detalle público de un producto activo. 404 si no existe o está inactivo.
+ */
+export async function getProductDetail(id: number): Promise<ProductDetailResponse> {
+  ensureValidId(id, "Id de producto");
+
+  return fetchWithErrorHandling<ProductDetailResponse>(`/api/v1/catalog/products/${id}`, {
+    method: "GET",
+  });
+}
+
+/**
+ * GET /api/v1/catalog/commerce-branches/{id}
+ * Detalle público de una sucursal/tienda activa. 404 si no existe o está inactiva.
+ */
+export async function getBranchDetail(id: number): Promise<BranchDetailResponse> {
+  ensureValidId(id, "Id de sucursal");
+
+  return fetchWithErrorHandling<BranchDetailResponse>(`/api/v1/catalog/commerce-branches/${id}`, {
+    method: "GET",
+  });
 }

--- a/app/frontend/src/lib/api/app-orders.ts
+++ b/app/frontend/src/lib/api/app-orders.ts
@@ -1,0 +1,71 @@
+import { ApiError, fetchWithErrorHandling } from "./client";
+import type { CreateOrderPayload, CreateOrderResponse } from "@/types/app-orders";
+
+/**
+ * Valida el payload antes de gastar una llamada de red, siguiendo el mismo
+ * patrón que `ensureValidCoordinates` en app-catalog.ts.
+ *
+ * @throws {ApiError} 422 si el payload es inválido.
+ */
+function ensureValidOrderPayload(payload: CreateOrderPayload): void {
+  if (!Number.isInteger(payload.commerce_branch_id) || payload.commerce_branch_id <= 0) {
+    throw new ApiError("Sucursal inválida para crear la orden.", 422);
+  }
+
+  if (!Array.isArray(payload.items) || payload.items.length === 0) {
+    throw new ApiError("La orden debe incluir al menos un producto.", 422);
+  }
+
+  const hasInvalidItem = payload.items.some(
+    (item) =>
+      !Number.isInteger(item.product_id) ||
+      item.product_id <= 0 ||
+      !Number.isInteger(item.quantity) ||
+      item.quantity < 1
+  );
+
+  if (hasInvalidItem) {
+    throw new ApiError("Cada producto debe tener id válido y cantidad mínima de 1.", 422);
+  }
+}
+
+/**
+ * POST /api/v1/orders
+ * Crea una orden real para el usuario autenticado. El backend fija el `user_id`
+ * desde el token; el cliente solo envía sucursal e ítems.
+ *
+ * Los errores llegan como `ApiError` tipado por status (403 sin permiso,
+ * 422 validación/stock insuficiente); ver `isInsufficientStockError` para
+ * distinguir el caso de stock.
+ *
+ * @throws {ApiError}
+ */
+export async function createOrder(payload: CreateOrderPayload): Promise<CreateOrderResponse> {
+  ensureValidOrderPayload(payload);
+
+  return fetchWithErrorHandling<CreateOrderResponse>("/api/v1/orders", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}
+
+/**
+ * Distingue el 422 de stock insuficiente del resto de errores de validación,
+ * para que la UI pueda mostrar un mensaje específico.
+ *
+ * El backend responde este caso con HTTP 422 y un mensaje que incluye
+ * "not available in the requested quantity" (OrderController@store).
+ */
+export function isInsufficientStockError(error: unknown): error is ApiError {
+  if (!(error instanceof ApiError) || error.status !== 422) {
+    return false;
+  }
+
+  const raw = error.data;
+  const backendMessage =
+    raw && typeof raw === "object" && "message" in raw
+      ? String((raw as { message: unknown }).message ?? "")
+      : "";
+
+  return backendMessage.toLowerCase().includes("not available in the requested quantity");
+}

--- a/app/frontend/src/types/app-catalog.adapters.ts
+++ b/app/frontend/src/types/app-catalog.adapters.ts
@@ -1,11 +1,38 @@
-import type { AppStoreCatalogItem } from "@/lib/app/mock-catalog";
-import type { NearbyProduct, NearbyProductsResponse } from "./app-catalog";
+import type { BranchDetail, NearbyBranch, NearbyProduct, NearbyProductsResponse, ProductDetail } from "./app-catalog";
 
-export interface DiscoverNearbyCard extends AppStoreCatalogItem {
+export interface DiscoverNearbyCard {
   productId: number;
   branchId: number | null;
+  name: string;
+  category: string;
+  address: string;
+  price: number;
+  originalPrice: number;
+  available: number;
   distanceKm: number;
   imageUrl?: string | null;
+  /** Horario de recogida de hoy en la sucursal asignada, o null si no hay dato real. */
+  pickupSchedule: string | null;
+}
+
+/**
+ * Resuelve el horario de recogida de HOY para la sucursal asignada al producto.
+ * day_of_week: 0=Domingo, 6=Sábado (mismo criterio que Date.getDay()).
+ * Sin dato real → null (la UI decide el estado neutro, nunca se fabrica un horario).
+ */
+function getTodayPickupSchedule(branch: NearbyBranch | null): string | null {
+  if (!branch?.hours || branch.hours.length === 0) {
+    return null;
+  }
+
+  const todayIndex = new Date().getDay();
+  const todayHours = branch.hours.find((hour) => hour.day_of_week === todayIndex);
+
+  if (!todayHours) {
+    return null;
+  }
+
+  return `Hoy ${todayHours.open_time.slice(0, 5)} - ${todayHours.close_time.slice(0, 5)}`;
 }
 
 export interface DiscoverMapPin {
@@ -51,8 +78,7 @@ function isValidCoordinates(lat: number, lng: number): boolean {
 }
 
 function getProductCategoryLabel(product: NearbyProduct): string {
-  const categoryId = toNumber(product.product_category_id ?? product.category_id, 0);
-  return categoryId > 0 ? `Categoria ${categoryId}` : "Sin categoria";
+  return toText(product.category, "Sin categoría");
 }
 
 function getProductPrice(product: NearbyProduct): number {
@@ -123,23 +149,17 @@ export function mapNearbyProductToDiscoverCard(product: NearbyProduct): Discover
       : displayPrice;
 
   return {
-    id: nearestBranch?.id ?? product.id,
-    name: toText(nearestBranch?.commerce_name ?? nearestBranch?.name ?? product.name ?? product.title, "Comercio cercano"),
-    category: product.category_id ? `Categoria ${product.category_id}` : "Sin categoria",
+    productId: product.id,
+    branchId: nearestBranch?.id ?? null,
+    name: toText(nearestBranch?.commerce_name ?? product.commerce_name ?? nearestBranch?.name ?? product.name ?? product.title, "Comercio cercano"),
+    category: getProductCategoryLabel(product),
     address: toText(nearestBranch?.address, "Ubicacion no disponible"),
-    rating: 0,
-    reviews: 0,
     price: displayPrice,
     originalPrice,
     available: toNumber(product.quantity_available, 1),
-    pickupTime: "Consultar con el comercio",
-    deliveryTime: "Consultar disponibilidad",
-    deliveryCost: 0,
-    description: toText(product.description, "Producto cercano segun tu ubicacion."),
-    productId: product.id,
-    branchId: nearestBranch?.id ?? null,
     distanceKm,
     imageUrl: getProductImageUrl(product),
+    pickupSchedule: getTodayPickupSchedule(nearestBranch),
   };
 }
 
@@ -206,4 +226,73 @@ export function mapNearbyProductsToMapPins(
   }
 
   return Array.from(pinsByBranch.values()).sort((a, b) => a.distanceKm - b.distanceKm);
+}
+
+// ============================================
+// Detalle de producto (GET /catalog/products/{id})
+// ============================================
+
+export interface ProductDetailView {
+  id: number;
+  title: string;
+  category: string;
+  description: string;
+  commerceName: string;
+  price: number;
+  originalPrice: number;
+  quantityAvailable: number;
+  photoUrl: string | null;
+}
+
+/**
+ * Degradación honesta: ante dato ausente se muestra un estado neutro real
+ * ("Sin categoría", "Sin descripción disponible."), nunca un valor del prototipo.
+ */
+export function mapProductDetailToView(detail: ProductDetail): ProductDetailView {
+  const price = detail.discounted_price ?? detail.original_price;
+
+  return {
+    id: detail.id,
+    title: toText(detail.title, "Producto"),
+    category: toText(detail.category, "Sin categoría"),
+    description: toText(detail.description, "Sin descripción disponible."),
+    commerceName: toText(detail.commerce_name, "Proveedor"),
+    price: toNumber(price),
+    originalPrice: toNumber(detail.original_price, price),
+    quantityAvailable: toNumber(detail.quantity_available, 0),
+    photoUrl: detail.photos?.[0]?.presigned_url ?? null,
+  };
+}
+
+// ============================================
+// Detalle de tienda/sucursal (GET /catalog/commerce-branches/{id})
+// ============================================
+
+export interface BranchDetailView {
+  id: number;
+  commerceName: string;
+  branchName: string;
+  address: string;
+  scheduleLabel: string;
+  photoUrl: string | null;
+}
+
+/**
+ * Sin rating/reviews: no existe modelo de reseñas aún (SCRUM-350, post-MVP).
+ * Se omite la sección en vez de fabricar un valor, siguiendo la decisión
+ * de degradación honesta acordada para esta fase.
+ */
+export function mapBranchDetailToView(detail: BranchDetail): BranchDetailView {
+  const hasHours = Array.isArray(detail.hours) && detail.hours.length > 0;
+
+  return {
+    id: detail.id,
+    commerceName: toText(detail.commerce_name, "Proveedor"),
+    branchName: toText(detail.name, "Sucursal"),
+    address: toText(detail.address, "Ubicación no disponible"),
+    scheduleLabel: hasHours
+      ? `${detail.hours![0].open_time} - ${detail.hours![0].close_time}`
+      : "Consultar con el comercio",
+    photoUrl: detail.photos?.[0]?.presigned_url ?? null,
+  };
 }

--- a/app/frontend/src/types/app-catalog.ts
+++ b/app/frontend/src/types/app-catalog.ts
@@ -8,6 +8,15 @@ export interface NearbyProductsParams {
   page?: number;
 }
 
+/** day_of_week: 0=Domingo, 6=Sábado (mismo criterio que Date.getDay() en JS) */
+export interface NearbyBranchHour {
+  id: number;
+  day_of_week: number;
+  open_time: string;
+  close_time: string;
+  note?: string | null;
+}
+
 export interface NearbyBranch {
   id: number;
   name: string;
@@ -16,6 +25,7 @@ export interface NearbyBranch {
   longitude: number | null;
   distance_km?: number | null;
   commerce_name?: string | null;
+  hours?: NearbyBranchHour[];
 }
 
 export interface NearbyProduct {
@@ -30,9 +40,74 @@ export interface NearbyProduct {
   description?: string | null;
   category_id?: number | null;
   product_category_id?: number | null;
+  /** Nombre real de la categoría (ProductResource::category, whenLoaded). Ausente si la relación no se cargó. */
+  category?: string | null;
+  /** Nombre real del comercio propietario (ProductResource::commerce_name, whenLoaded). */
+  commerce_name?: string | null;
   nearest_branch_distance_km: number;
   nearest_branch: NearbyBranch | null;
   commerce_branches?: NearbyBranch[];
+}
+
+/**
+ * Detalle de producto: GET /api/v1/catalog/products/{id}
+ * Shape de ProductResource (backend), solo items activos.
+ */
+export interface ProductDetail {
+  id: number;
+  commerce_id: number;
+  commerce_name?: string | null;
+  product_category_id: number | null;
+  category?: string | null;
+  title: string;
+  description: string | null;
+  product_type: "single" | "package";
+  original_price: number;
+  discounted_price: number | null;
+  quantity_total: number;
+  quantity_available: number;
+  available_for_packaging?: number | null;
+  expires_at?: string | null;
+  photos?: Array<{ id: number; presigned_url?: string | null; file_path?: string }>;
+  status: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface ProductDetailResponse {
+  status: boolean;
+  message: string | null;
+  data: ProductDetail;
+}
+
+/**
+ * Detalle de sucursal/tienda: GET /api/v1/catalog/commerce-branches/{id}
+ * Shape de CommerceBranchResource (backend), solo sucursales activas.
+ */
+export interface BranchDetail {
+  id: number;
+  commerce_id: number;
+  commerce_name?: string | null;
+  name: string;
+  address?: string | null;
+  department?: string | null;
+  city?: string | null;
+  neighborhood?: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  phone?: string | null;
+  email?: string | null;
+  is_active?: boolean | null;
+  hours?: Array<{ day_of_week: string; open_time: string; close_time: string; note?: string | null }>;
+  photos?: Array<{ id: number; presigned_url?: string | null; file_path?: string }>;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface BranchDetailResponse {
+  status: boolean;
+  message: string | null;
+  data: BranchDetail;
 }
 
 export interface NearbyProductsResponse {

--- a/app/frontend/src/types/app-orders.ts
+++ b/app/frontend/src/types/app-orders.ts
@@ -1,0 +1,61 @@
+/**
+ * Tipos del módulo app para creación y lectura de órdenes.
+ * Alineados al contrato del backend: StoreOrderRequest + OrderResource.
+ */
+
+/** Estados de orden definidos en el backend (Constant::ORDER_STATUS_*). */
+export type AppOrderStatus =
+  | "pending"
+  | "confirmed"
+  | "preparing"
+  | "ready"
+  | "delivered"
+  | "cancelled";
+
+/** Ítem que el cliente envía al crear una orden. */
+export interface CreateOrderItemInput {
+  product_id: number;
+  quantity: number;
+}
+
+/**
+ * Cuerpo de POST /api/v1/orders.
+ * `user_id` NO se envía: el backend lo fija desde el token (ver StoreOrderRequest).
+ */
+export interface CreateOrderPayload {
+  commerce_branch_id: number;
+  items: CreateOrderItemInput[];
+}
+
+/** Ítem de orden devuelto por el backend (OrderItemResource). */
+export interface AppOrderItem {
+  id: number;
+  order_id: number;
+  product_id: number;
+  quantity: number;
+  unit_price: number;
+  subtotal: number;
+  created_at?: string;
+  updated_at?: string;
+}
+
+/**
+ * Orden devuelta por el backend (OrderResource).
+ * `user` y `commerce_branch` llegan como objetos anidados; se tipan laxos
+ * porque el flujo de compra solo consume id/estado/total/ítems.
+ */
+export interface AppOrder {
+  id: number;
+  total_price: number;
+  status: AppOrderStatus;
+  items?: AppOrderItem[];
+  created_at?: string;
+  updated_at?: string;
+}
+
+/** Envelope estándar del backend: { status, message, data }. */
+export interface CreateOrderResponse {
+  status: boolean;
+  message: string | null;
+  data: AppOrder;
+}


### PR DESCRIPTION
## Resumen

Fase 1 del plan de checkout/pago (SCRUM-291): conecta el catálogo de la app móvil (discover, detalle de producto, detalle de tienda) a datos reales del backend, eliminando información quemada del prototipo.

- Backend expone `category` y `commerce_name` en `ProductResource`/`CommerceBranchResource`
- Endpoints públicos nuevos `catalog/products/{id}` y `catalog/commerce-branches/{id}` (solo items activos) para el detalle de la app
- Corregido `NearbyProductResource`/`NearbyBranchResource`: heredaban de `JsonResource` en vez de `ProductResource`/`CommerceBranchResource`, devolviendo modelos crudos sin filtrar (categoría anidada, sin horarios)
- Eager-loading ajustado para traer horarios de recogida de la sucursal asignada sin N+1
- Detalle de producto y de tienda reescritos con fetch real (antes 100% mock/query-params)
- Discover muestra categoría y horario de recogida reales, sin rating ni textos de prototipo fabricados

Resuelve: SCRUM-304, SCRUM-290, SCRUM-289

## Test plan
- [x] Backend: 394/394 tests, incluyendo 7 tests nuevos de `CatalogFeatureTest` y 2 nuevos en `NearbyFeatureTest`
- [x] Frontend: `tsc --noEmit` y `eslint` limpios en todo `src/`
- [x] Verificación E2E manual contra datos reales sembrados (producto y sucursal activos): categoría, nombre de proveedor, descripción, horario de recogida — todos reales, sin "dummy"
- [x] Estados de no-encontrado verificados (producto/sucursal inexistente e id inválido)