### PR TITLE
feat(app): checkout con pago simulado plug-in (Fases 2-4 SCRUM-291)

### DIFF
--- a/app/backend/.env.example
+++ b/app/backend/.env.example
@@ -92,6 +92,11 @@ CORS_SUPPORTS_CREDENTIALS=true
 FRONTEND_URL=http://localhost:3000
 FRONTEND_PROD_URL=https://sdjr-frontend.vercel.app
 
+# Pasarela de pagos (plug-in): clave del map en config/payments.php.
+# 'fake' = pasarela simulada (aprueba todo; rechaza con simulate=reject).
+PAYMENTS_GATEWAY=fake
+PAYMENTS_CURRENCY=COP
+
 # Sanctum Configuration (CORS related)
 SANCTUM_STATEFUL_DOMAINS=localhost:3000,sdjr-frontend.vercel.app
 SESSION_DOMAIN=localhost

--- a/app/backend/app/Contracts/PaymentGatewayInterface.php
+++ b/app/backend/app/Contracts/PaymentGatewayInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Contracts;
+
+use App\Payments\PaymentIntent;
+use App\Payments\PaymentResult;
+
+/**
+ * Contrato de pasarela de pagos (patrón plug-in).
+ *
+ * Este es el primer contrato con inversión de dependencia del proyecto:
+ * el dominio (PaymentService) depende de esta interfaz, nunca de una
+ * implementación concreta. La implementación activa se resuelve desde
+ * config('payments.gateway') en PaymentServiceProvider.
+ *
+ * Para enchufar una pasarela real (Wompi, Stripe, etc.):
+ *   1. Crear una clase en App\Payments\Gateways que implemente esta interfaz.
+ *   2. Registrarla en el map de config/payments.php.
+ *   3. Cambiar PAYMENTS_GATEWAY en el entorno.
+ * Ningún archivo de dominio, órdenes, HTTP ni frontend cambia.
+ */
+interface PaymentGatewayInterface
+{
+    /**
+     * Autoriza (y en pasarelas síncronas, resuelve) el cobro de una intención.
+     * Nunca lanza por rechazo de negocio: un rechazo es un PaymentResult con
+     * status Rejected/Failed. Las excepciones quedan para fallas de
+     * infraestructura (red, credenciales).
+     */
+    public function authorize(PaymentIntent $intent): PaymentResult;
+
+    /**
+     * Consulta el estado de una transacción por la referencia del proveedor.
+     * Pensado para pasarelas asíncronas futuras (confirmación diferida).
+     */
+    public function status(string $providerReference): PaymentResult;
+}

--- a/app/backend/app/Enums/TransactionStatus.php
+++ b/app/backend/app/Enums/TransactionStatus.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Enums;
+
+/**
+ * Estado de una transacción de pago (cargo al comprador).
+ *
+ * Dimensión independiente del estado de la orden: una orden pending puede
+ * acumular transacciones rejected/failed; solo una approved dispara la
+ * confirmación de la orden (vía OrderService, no desde aquí).
+ */
+enum TransactionStatus: string
+{
+    case Initiated = 'initiated';
+    case Approved = 'approved';
+    case Rejected = 'rejected';
+    case Failed = 'failed';
+
+    /**
+     * Un estado final ya no cambia: la transacción no se reintenta,
+     * se crea una nueva si el usuario vuelve a intentar pagar.
+     */
+    public function isFinal(): bool
+    {
+        return $this !== self::Initiated;
+    }
+}

--- a/app/backend/app/Http/Controllers/Api/V1/TransactionController.php
+++ b/app/backend/app/Http/Controllers/Api/V1/TransactionController.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Api\V1;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\StoreOrderTransactionRequest;
+use App\Http\Resources\Api\V1\TransactionResource;
+use App\Models\Order;
+use App\Payments\Gateways\FakePaymentGateway;
+use App\Services\PaymentService;
+use App\Traits\ApiResponseTrait;
+use DomainException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
+
+/**
+ * @OA\Tag(
+ *     name="Transactions",
+ *     description="Cobro de órdenes (transacciones de pago del comprador)"
+ * )
+ */
+class TransactionController extends Controller
+{
+    use ApiResponseTrait;
+
+    public function __construct(private readonly PaymentService $paymentService) {}
+
+    /**
+     * @OA\Post(
+     *   path="/api/v1/orders/{id}/transactions",
+     *   tags={"Transactions"},
+     *   summary="Pagar una orden (crea una transacción de cobro)",
+     *   description="Cobra la orden vía la pasarela activa (config payments.gateway). Aprobado: la orden pasa a confirmed. Rechazado: la transacción queda rejected y la orden sigue pending.",
+     *   security={{"sanctum":{}}},
+     *
+     *   @OA\Parameter(name="id", in="path", required=true, @OA\Schema(type="integer")),
+     *
+     *   @OA\RequestBody(required=false, @OA\JsonContent(ref="#/components/schemas/StoreOrderTransactionRequest")),
+     *
+     *   @OA\Response(response=201, description="Pago aprobado", @OA\JsonContent(@OA\Property(property="data", ref="#/components/schemas/TransactionResource"))),
+     *   @OA\Response(response=402, description="Pago rechazado por la pasarela", @OA\JsonContent(@OA\Property(property="data", ref="#/components/schemas/TransactionResource"))),
+     *   @OA\Response(response=403, description="Sin permiso o no es dueño de la orden"),
+     *   @OA\Response(response=404, description="Orden no encontrada"),
+     *   @OA\Response(response=422, description="La orden no es pagable (no pending o ya cobrada)")
+     * )
+     */
+    public function store(StoreOrderTransactionRequest $request, int $id): JsonResponse
+    {
+        try {
+            // La existencia + ownership ya la validó el Request; findOrFail
+            // cubre la ventana entre ambas consultas.
+            $order = Order::findOrFail($id);
+            $validated = $request->validated();
+
+            $options = array_filter([
+                FakePaymentGateway::SIMULATE_OPTION => $validated['simulate'] ?? null,
+            ]);
+
+            $transaction = $this->paymentService->pay(
+                $order,
+                $options,
+                isset($validated['payment_method_id']) ? (int) $validated['payment_method_id'] : null,
+            );
+
+            if ($transaction->status->value === 'approved') {
+                return $this->createdResponse(new TransactionResource($transaction), 'Payment approved');
+            }
+
+            // Rechazo de negocio de la pasarela: la transacción existe (auditoría)
+            // pero el cobro no ocurrió. 402 Payment Required comunica el fallo.
+            return response()->json([
+                'status' => false,
+                'message' => 'Payment was not approved',
+                'data' => new TransactionResource($transaction),
+            ], Response::HTTP_PAYMENT_REQUIRED);
+        } catch (DomainException $e) {
+            return $this->errorResponse($e->getMessage(), Response::HTTP_UNPROCESSABLE_ENTITY);
+        } catch (Throwable $e) {
+            Log::error('Payment processing failed', ['order_id' => $id, 'error' => $e->getMessage()]);
+
+            return $this->errorResponse('Error processing payment', Response::HTTP_INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/app/backend/app/Http/Requests/Api/V1/StoreOrderTransactionRequest.php
+++ b/app/backend/app/Http/Requests/Api/V1/StoreOrderTransactionRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Api\V1;
+
+use App\Models\Order;
+use App\Payments\Gateways\FakePaymentGateway;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * @OA\Schema(
+ *     schema="StoreOrderTransactionRequest",
+ *
+ *     @OA\Property(property="payment_method_id", type="integer", nullable=true, example=1, description="Metodo de pago tokenizado del usuario (opcional)"),
+ *     @OA\Property(property="simulate", type="string", nullable=true, enum={"reject"}, description="Solo pasarela fake: fuerza el rechazo determinista para QA. Una pasarela real ignora este campo.")
+ * )
+ */
+class StoreOrderTransactionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+        if (! $user || ! $user->can('customer.orders.pay')) {
+            return false;
+        }
+
+        // Solo el dueño de la orden puede pagarla. El id viene de la ruta,
+        // nunca del body.
+        $orderId = (int) ($this->route('id') ?? 0);
+        if ($orderId <= 0) {
+            return false;
+        }
+
+        return Order::query()
+            ->whereKey($orderId)
+            ->where('user_id', $user->id)
+            ->exists();
+    }
+
+    public function rules(): array
+    {
+        return [
+            'payment_method_id' => [
+                'nullable',
+                'integer',
+                // El método debe pertenecer al usuario autenticado.
+                'exists:payment_methods,id,user_id,'.$this->user()->id,
+            ],
+            'simulate' => ['nullable', 'string', 'in:'.FakePaymentGateway::SIMULATE_REJECT],
+        ];
+    }
+}

--- a/app/backend/app/Http/Resources/Api/V1/TransactionResource.php
+++ b/app/backend/app/Http/Resources/Api/V1/TransactionResource.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Api\V1;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @OA\Schema(
+ *     schema="TransactionResource",
+ *     type="object",
+ *     title="Transaction Resource",
+ *     description="Cargo/pago de una orden. El payload crudo del gateway NO se expone: es trazabilidad interna.",
+ *
+ *     @OA\Property(property="id", type="integer", example=1),
+ *     @OA\Property(property="order_id", type="integer", example=10),
+ *     @OA\Property(property="payment_method_id", type="integer", nullable=true, example=1),
+ *     @OA\Property(property="provider", type="string", example="fake"),
+ *     @OA\Property(property="external_id", type="string", nullable=true, example="fake_01HXX..."),
+ *     @OA\Property(property="status", type="string", enum={"initiated","approved","rejected","failed"}, example="approved"),
+ *     @OA\Property(property="amount", type="number", format="float", example=16000),
+ *     @OA\Property(property="currency", type="string", example="COP"),
+ *     @OA\Property(property="failure_reason", type="string", nullable=true, example="Pago rechazado por la entidad emisora (simulado)."),
+ *     @OA\Property(property="created_at", type="string", format="date-time")
+ * )
+ */
+class TransactionResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'order_id' => $this->order_id,
+            'payment_method_id' => $this->payment_method_id,
+            'provider' => $this->provider,
+            'external_id' => $this->external_id,
+            'status' => $this->status,
+            'amount' => $this->amount,
+            'currency' => $this->currency,
+            // Único dato del payload que el cliente necesita; el resto del
+            // payload crudo del gateway queda fuera de la respuesta a propósito.
+            'failure_reason' => $this->payload['failure_reason'] ?? null,
+            'created_at' => $this->created_at,
+        ];
+    }
+}

--- a/app/backend/app/Models/Order.php
+++ b/app/backend/app/Models/Order.php
@@ -45,6 +45,11 @@ class Order extends Model
         return $this->hasMany(OrderItem::class);
     }
 
+    public function transactions(): HasMany
+    {
+        return $this->hasMany(Transaction::class);
+    }
+
     // Accessor para obtener el comercio desde la sucursal
     public function getCommerceAttribute()
     {

--- a/app/backend/app/Models/PaymentMethod.php
+++ b/app/backend/app/Models/PaymentMethod.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * Método de pago tokenizado del comprador.
+ * NO confundir con CommercePayoutMethod (liquidación al aliado).
+ */
+class PaymentMethod extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'user_id',
+        'provider',
+        'token',
+        'last4',
+        'brand',
+        'exp_month',
+        'exp_year',
+        'is_default',
+    ];
+
+    protected $casts = [
+        'id' => 'integer',
+        'user_id' => 'integer',
+        'exp_month' => 'integer',
+        'exp_year' => 'integer',
+        'is_default' => 'boolean',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function transactions(): HasMany
+    {
+        return $this->hasMany(Transaction::class);
+    }
+}

--- a/app/backend/app/Models/Transaction.php
+++ b/app/backend/app/Models/Transaction.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\TransactionStatus;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * Cargo/pago del comprador sobre una orden.
+ * La lógica de cobro vive en PaymentService; este modelo solo declara
+ * datos, casts y relaciones.
+ */
+class Transaction extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    protected $fillable = [
+        'user_id',
+        'order_id',
+        'payment_method_id',
+        'provider',
+        'external_id',
+        'status',
+        'amount',
+        'currency',
+        'payload',
+    ];
+
+    protected $casts = [
+        'id' => 'integer',
+        'user_id' => 'integer',
+        'order_id' => 'integer',
+        'payment_method_id' => 'integer',
+        'status' => TransactionStatus::class,
+        'amount' => 'float',
+        'payload' => 'array',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function order(): BelongsTo
+    {
+        return $this->belongsTo(Order::class);
+    }
+
+    public function paymentMethod(): BelongsTo
+    {
+        return $this->belongsTo(PaymentMethod::class);
+    }
+}

--- a/app/backend/app/Models/User.php
+++ b/app/backend/app/Models/User.php
@@ -137,6 +137,26 @@ class User extends Authenticatable
     }
 
     /**
+     * Transacciones de pago del usuario (cargos como comprador).
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function transactions()
+    {
+        return $this->hasMany(Transaction::class);
+    }
+
+    /**
+     * Métodos de pago tokenizados del usuario.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function paymentMethods()
+    {
+        return $this->hasMany(PaymentMethod::class);
+    }
+
+    /**
      * Get commerce branches where this user is assigned as branch_leader.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany

--- a/app/backend/app/Payments/Gateways/FakePaymentGateway.php
+++ b/app/backend/app/Payments/Gateways/FakePaymentGateway.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Payments\Gateways;
+
+use App\Contracts\PaymentGatewayInterface;
+use App\Enums\TransactionStatus;
+use App\Payments\PaymentIntent;
+use App\Payments\PaymentResult;
+use Illuminate\Support\Str;
+
+/**
+ * Pasarela simulada para desarrollo y QA (no hay proveedor real contratado).
+ *
+ * Comportamiento determinista, sin aleatoriedad:
+ *  - Aprueba todo cobro por defecto.
+ *  - Rechaza si la intención trae options['simulate'] === 'reject' — el
+ *    disparador que QA usa para validar el camino de fallo. Una pasarela
+ *    real simplemente ignora esa opción.
+ */
+class FakePaymentGateway implements PaymentGatewayInterface
+{
+    public const SIMULATE_OPTION = 'simulate';
+
+    public const SIMULATE_REJECT = 'reject';
+
+    public function authorize(PaymentIntent $intent): PaymentResult
+    {
+        // Latencia mínima simulada para que la UI ejercite su estado "procesando".
+        usleep(150_000);
+
+        if (($intent->options[self::SIMULATE_OPTION] ?? null) === self::SIMULATE_REJECT) {
+            return new PaymentResult(
+                status: TransactionStatus::Rejected,
+                externalId: $this->fakeReference(),
+                failureReason: 'Pago rechazado por la entidad emisora (simulado).',
+                rawPayload: [
+                    'gateway' => 'fake',
+                    'simulated' => true,
+                    'outcome' => 'rejected',
+                ],
+            );
+        }
+
+        return new PaymentResult(
+            status: TransactionStatus::Approved,
+            externalId: $this->fakeReference(),
+            rawPayload: [
+                'gateway' => 'fake',
+                'simulated' => true,
+                'outcome' => 'approved',
+            ],
+        );
+    }
+
+    public function status(string $providerReference): PaymentResult
+    {
+        // La pasarela fake es síncrona: todo cobro quedó resuelto en authorize().
+        return new PaymentResult(
+            status: TransactionStatus::Approved,
+            externalId: $providerReference,
+            rawPayload: ['gateway' => 'fake', 'simulated' => true],
+        );
+    }
+
+    private function fakeReference(): string
+    {
+        return 'fake_'.Str::ulid();
+    }
+}

--- a/app/backend/app/Payments/PaymentIntent.php
+++ b/app/backend/app/Payments/PaymentIntent.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Payments;
+
+/**
+ * Intención de cobro que el dominio entrega a la pasarela.
+ *
+ * DTO inmutable: el gateway recibe exactamente lo que necesita para autorizar,
+ * nada más. El monto SIEMPRE proviene de la orden en backend (nunca del
+ * cliente); PaymentService es el único constructor legítimo de este objeto.
+ *
+ * `options` transporta banderas específicas de una implementación (ej. el
+ * `simulate` del FakePaymentGateway). Las pasarelas ignoran las opciones que
+ * no reconocen: nada de esto contamina el dominio.
+ */
+final readonly class PaymentIntent
+{
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    public function __construct(
+        public int $orderId,
+        public float $amount,
+        public string $currency,
+        public ?int $paymentMethodId = null,
+        public array $options = [],
+    ) {}
+}

--- a/app/backend/app/Payments/PaymentResult.php
+++ b/app/backend/app/Payments/PaymentResult.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Payments;
+
+use App\Enums\TransactionStatus;
+
+/**
+ * Resultado que la pasarela devuelve al dominio.
+ *
+ * DTO inmutable. `rawPayload` es la respuesta cruda del proveedor y se
+ * persiste SOLO para trazabilidad interna (transactions.payload); nunca se
+ * expone al cliente (ver TransactionResource).
+ */
+final readonly class PaymentResult
+{
+    /**
+     * @param  array<string, mixed>  $rawPayload
+     */
+    public function __construct(
+        public TransactionStatus $status,
+        public ?string $externalId = null,
+        public ?string $failureReason = null,
+        public array $rawPayload = [],
+    ) {}
+
+    public function isApproved(): bool
+    {
+        return $this->status === TransactionStatus::Approved;
+    }
+}

--- a/app/backend/app/Providers/PaymentServiceProvider.php
+++ b/app/backend/app/Providers/PaymentServiceProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use App\Contracts\PaymentGatewayInterface;
+use Illuminate\Support\ServiceProvider;
+use InvalidArgumentException;
+
+/**
+ * Único punto de acoplamiento entre el contrato de pasarela y su
+ * implementación concreta (patrón plug-in, ver PaymentGatewayInterface).
+ *
+ * Primer binding de contenedor por contrato del proyecto: si necesitas
+ * otro contrato intercambiable (ej. SMS, facturación), copia este patrón —
+ * interfaz en App\Contracts, implementaciones en un namespace propio,
+ * selección por config, binding aquí o en un provider dedicado.
+ */
+class PaymentServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        $this->app->singleton(PaymentGatewayInterface::class, function ($app) {
+            $gateway = (string) config('payments.gateway');
+            $map = (array) config('payments.map');
+
+            if (! isset($map[$gateway])) {
+                throw new InvalidArgumentException(
+                    "Payment gateway [{$gateway}] is not registered in config/payments.php map."
+                );
+            }
+
+            return $app->make($map[$gateway]);
+        });
+    }
+}

--- a/app/backend/app/Services/PaymentService.php
+++ b/app/backend/app/Services/PaymentService.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Constants\Constant;
+use App\Contracts\PaymentGatewayInterface;
+use App\Enums\TransactionStatus;
+use App\Models\Order;
+use App\Models\Transaction;
+use App\Payments\PaymentIntent;
+use DomainException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Orquesta el cobro de una orden, desacoplado del dominio de órdenes.
+ *
+ * Principios:
+ *  - Depende del contrato PaymentGatewayInterface (DIP): la pasarela activa
+ *    la decide config('payments.gateway'), no este servicio.
+ *  - El monto SIEMPRE se toma de la orden en backend, jamás del cliente.
+ *  - La confirmación de la orden se DELEGA a OrderService (única fuente de
+ *    verdad de transiciones de estado y descuento de stock).
+ *  - Idempotencia: una orden con transacción approved no admite otro cobro.
+ */
+class PaymentService
+{
+    public function __construct(
+        private readonly PaymentGatewayInterface $gateway,
+        private readonly OrderService $orderService,
+    ) {}
+
+    /**
+     * Cobra una orden pending. Devuelve la transacción resultante
+     * (approved, rejected o failed — el rechazo NO es excepción).
+     *
+     * @param  array<string, mixed>  $options  Banderas específicas de gateway (ej. simulate=reject en fake).
+     *
+     * @throws DomainException si la orden no es pagable (no pending, o ya cobrada).
+     */
+    public function pay(Order $order, array $options = [], ?int $paymentMethodId = null): Transaction
+    {
+        return DB::transaction(function () use ($order, $options, $paymentMethodId) {
+            // Lock pesimista: dos submits simultáneos del mismo pago se serializan
+            // y el segundo verá el estado ya confirmado / la transacción approved.
+            $order = Order::query()->lockForUpdate()->findOrFail($order->id);
+
+            $this->assertPayable($order);
+
+            $transaction = Transaction::create([
+                'user_id' => $order->user_id,
+                'order_id' => $order->id,
+                'payment_method_id' => $paymentMethodId,
+                'provider' => (string) config('payments.gateway'),
+                'status' => TransactionStatus::Initiated,
+                'amount' => $order->total_price,
+                'currency' => (string) config('payments.currency', 'COP'),
+            ]);
+
+            $result = $this->gateway->authorize(new PaymentIntent(
+                orderId: $order->id,
+                amount: (float) $order->total_price,
+                currency: $transaction->currency,
+                paymentMethodId: $paymentMethodId,
+                options: $options,
+            ));
+
+            $transaction->external_id = $result->externalId;
+            $transaction->status = $result->status;
+            $transaction->payload = array_merge($result->rawPayload, array_filter([
+                'failure_reason' => $result->failureReason,
+            ]));
+            $transaction->save();
+
+            if ($result->isApproved()) {
+                // Delegado a OrderService: reutiliza validateStatusTransition
+                // y el descuento de stock existente. No se duplica aquí.
+                $this->orderService->patchStatus($order->id, Constant::ORDER_STATUS_CONFIRMED);
+            } else {
+                Log::info('Payment not approved', [
+                    'order_id' => $order->id,
+                    'transaction_id' => $transaction->id,
+                    'status' => $result->status->value,
+                    'reason' => $result->failureReason,
+                ]);
+            }
+
+            return $transaction->refresh();
+        });
+    }
+
+    /**
+     * Una orden es pagable solo si está pending y no tiene ya un cobro aprobado.
+     *
+     * @throws DomainException
+     */
+    protected function assertPayable(Order $order): void
+    {
+        if ($order->status !== Constant::ORDER_STATUS_PENDING) {
+            throw new DomainException('Order is not payable in its current status');
+        }
+
+        $alreadyPaid = $order->transactions()
+            ->where('status', TransactionStatus::Approved->value)
+            ->exists();
+
+        if ($alreadyPaid) {
+            throw new DomainException('Order already has an approved transaction');
+        }
+    }
+}

--- a/app/backend/bootstrap/providers.php
+++ b/app/backend/bootstrap/providers.php
@@ -2,4 +2,5 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    App\Providers\PaymentServiceProvider::class,
 ];

--- a/app/backend/config/payments.php
+++ b/app/backend/config/payments.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Payments\Gateways\FakePaymentGateway;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pasarela de pagos activa
+    |--------------------------------------------------------------------------
+    |
+    | Clave del map de abajo. Cambiar la pasarela = cambiar esta variable de
+    | entorno (+ tener la clase registrada en el map). Ningún archivo de
+    | dominio, órdenes, HTTP ni frontend cambia: PaymentServiceProvider
+    | bindea PaymentGatewayInterface a la clase resuelta desde aquí.
+    |
+    | 'fake' es la pasarela simulada (sin proveedor real contratado):
+    | aprueba todo, rechaza con el flag de prueba simulate=reject.
+    |
+    */
+
+    'gateway' => env('PAYMENTS_GATEWAY', 'fake'),
+
+    'map' => [
+        'fake' => FakePaymentGateway::class,
+        // 'wompi' => WompiPaymentGateway::class,   // futura pasarela real
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Moneda por defecto
+    |--------------------------------------------------------------------------
+    */
+
+    'currency' => env('PAYMENTS_CURRENCY', 'COP'),
+
+];

--- a/app/backend/database/migrations/2026_07_22_000000_create_payment_methods_table.php
+++ b/app/backend/database/migrations/2026_07_22_000000_create_payment_methods_table.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Métodos de pago tokenizados del comprador (entidad "Payment Method" del ER).
+ * NO confundir con commerce_payout_methods (liquidación al aliado).
+ * Solo se guardan datos tokenizados/enmascarados: nunca el PAN completo.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('payment_methods', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')
+                ->constrained('users')
+                ->cascadeOnDelete();
+            $table->string('provider'); // pasarela dueña del token (ej. "fake", futura real)
+            $table->string('token')->nullable();
+            $table->string('last4', 4)->nullable();
+            $table->string('brand')->nullable();
+            $table->unsignedTinyInteger('exp_month')->nullable();
+            $table->unsignedSmallInteger('exp_year')->nullable();
+            $table->boolean('is_default')->default(false);
+            $table->timestamps();
+            $table->softDeletes();
+            $table->index('user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('payment_methods');
+    }
+};

--- a/app/backend/database/migrations/2026_07_22_000001_create_transactions_table.php
+++ b/app/backend/database/migrations/2026_07_22_000001_create_transactions_table.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\TransactionStatus;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Cargos/pagos del comprador (entidad "Transactions" del ER).
+ * Desacoplado del estado de la orden: una orden pending puede acumular
+ * transacciones rejected/failed; solo una approved la confirma.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('transactions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')
+                ->constrained('users')
+                ->cascadeOnDelete();
+            $table->foreignId('order_id')
+                ->constrained('orders')
+                ->cascadeOnDelete();
+            $table->foreignId('payment_method_id')
+                ->nullable()
+                ->constrained('payment_methods')
+                ->nullOnDelete();
+            $table->string('provider'); // gateway que procesó (ej. "fake")
+            $table->string('external_id')->nullable(); // referencia del gateway (el ER lo tipaba boolean: corregido a string)
+            $table->enum('status', array_column(TransactionStatus::cases(), 'value'))
+                ->default(TransactionStatus::Initiated->value);
+            $table->decimal('amount', 10, 2);
+            $table->string('currency', 3)->default('COP');
+            $table->json('payload')->nullable(); // respuesta cruda del gateway, solo trazabilidad interna
+            $table->timestamps();
+            $table->softDeletes();
+            $table->index('order_id');
+            $table->index('status');
+            $table->index('user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('transactions');
+    }
+};

--- a/app/backend/database/seeders/RolePermissionSeeder.php
+++ b/app/backend/database/seeders/RolePermissionSeeder.php
@@ -134,6 +134,7 @@ class RolePermissionSeeder extends Seeder
 
             // Permisos para Órdenes (Orders):
             ['name' => 'customer.orders.create', 'guard_name' => $guardName, 'description' => 'Crear órdenes como cliente', 'created_at' => now(), 'updated_at' => now()],
+            ['name' => 'customer.orders.pay', 'guard_name' => $guardName, 'description' => 'Pagar órdenes propias como cliente', 'created_at' => now(), 'updated_at' => now()],
             ['name' => 'customer.orders.show', 'guard_name' => $guardName, 'description' => 'Ver órdenes propias como cliente', 'created_at' => now(), 'updated_at' => now()],
             ['name' => 'customer.orders.index', 'guard_name' => $guardName, 'description' => 'Listar órdenes propias como cliente', 'created_at' => now(), 'updated_at' => now()],
             ['name' => 'provider.orders.index', 'guard_name' => $guardName, 'description' => 'Listar órdenes de sucursales como proveedor', 'created_at' => now(), 'updated_at' => now()],
@@ -447,6 +448,7 @@ class RolePermissionSeeder extends Seeder
         $userPermissions = [
 
             'customer.orders.create',
+            'customer.orders.pay',
             'customer.commerce-branches.my-favorites',
         ];
 

--- a/app/backend/routes/api.php
+++ b/app/backend/routes/api.php
@@ -30,6 +30,7 @@ use App\Http\Controllers\Api\V1\ProductCategoryController;
 use App\Http\Controllers\Api\V1\ProductController;
 use App\Http\Controllers\Api\V1\RoleController;
 use App\Http\Controllers\Api\V1\SupportStatusController;
+use App\Http\Controllers\Api\V1\TransactionController;
 use App\Http\Controllers\Api\V1\UserController;
 use Illuminate\Support\Facades\Route;
 
@@ -190,6 +191,7 @@ Route::prefix('v1')->group(function () {
 
         // Orders - CRUD completo
         Route::apiResource('orders', OrderController::class);
+        Route::post('orders/{id}/transactions', [TransactionController::class, 'store']);
         Route::patch('orders/{id}/status', [OrderController::class, 'patchStatus']);
         Route::get('my-orders', [OrderController::class, 'myOrders']);
         Route::get('commerce-branches/{branchId}/orders', [OrderController::class, 'commerceBranchOrders']);

--- a/app/backend/tests/Feature/Api/V1/OrderTransactionFeatureTest.php
+++ b/app/backend/tests/Feature/Api/V1/OrderTransactionFeatureTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Api\V1;
+
+use App\Constants\Constant;
+use App\Contracts\PaymentGatewayInterface;
+use App\Enums\TransactionStatus;
+use App\Models\CommerceBranch;
+use App\Models\Order;
+use App\Models\OrderItem;
+use App\Models\Product;
+use App\Models\Transaction;
+use App\Models\User;
+use App\Payments\PaymentIntent;
+use App\Payments\PaymentResult;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Tests\TestCase;
+
+class OrderTransactionFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Role::create(['name' => 'user', 'guard_name' => 'sanctum']);
+        Permission::create(['name' => 'customer.orders.pay', 'guard_name' => 'sanctum']);
+    }
+
+    private function customer(): User
+    {
+        $user = User::factory()->create();
+        $user->assignRole('user');
+        $user->givePermissionTo('customer.orders.pay');
+        Sanctum::actingAs($user);
+
+        return $user;
+    }
+
+    private function pendingOrderFor(User $user, float $total = 16000): Order
+    {
+        $branch = CommerceBranch::factory()->create();
+        $product = Product::factory()->create([
+            'commerce_id' => $branch->commerce_id,
+            'quantity_total' => 10,
+            'quantity_available' => 10,
+        ]);
+
+        $order = Order::factory()->create([
+            'user_id' => $user->id,
+            'commerce_branch_id' => $branch->id,
+            'total_price' => $total,
+            'status' => Constant::ORDER_STATUS_PENDING,
+        ]);
+
+        OrderItem::factory()->create([
+            'order_id' => $order->id,
+            'product_id' => $product->id,
+            'quantity' => 2,
+            'unit_price' => $total / 2,
+        ]);
+
+        return $order;
+    }
+
+    public function test_owner_pays_pending_order_and_it_gets_confirmed(): void
+    {
+        $user = $this->customer();
+        $order = $this->pendingOrderFor($user);
+        $product = $order->items()->first()->product;
+        $stockBefore = $product->quantity_total;
+
+        $response = $this->postJson("/api/v1/orders/{$order->id}/transactions", []);
+
+        $response->assertCreated();
+        $response->assertJsonPath('data.status', 'approved');
+        $response->assertJsonPath('data.amount', 16000);
+        $response->assertJsonPath('data.currency', 'COP');
+
+        $this->assertSame(Constant::ORDER_STATUS_CONFIRMED, $order->fresh()->status);
+        // El stock se descuenta UNA vez, via OrderService (comportamiento existente sobre quantity_total).
+        $this->assertSame($stockBefore - 2, $product->fresh()->quantity_total);
+    }
+
+    public function test_simulated_rejection_leaves_order_pending(): void
+    {
+        $user = $this->customer();
+        $order = $this->pendingOrderFor($user);
+
+        $response = $this->postJson("/api/v1/orders/{$order->id}/transactions", ['simulate' => 'reject']);
+
+        $response->assertStatus(402);
+        $response->assertJsonPath('data.status', 'rejected');
+        $response->assertJsonPath('status', false);
+        $this->assertNotNull($response->json('data.failure_reason'));
+
+        $this->assertSame(Constant::ORDER_STATUS_PENDING, $order->fresh()->status);
+        $this->assertSame(1, Transaction::where('order_id', $order->id)->count());
+    }
+
+    public function test_rejected_payment_can_be_retried_and_approved(): void
+    {
+        $user = $this->customer();
+        $order = $this->pendingOrderFor($user);
+
+        $this->postJson("/api/v1/orders/{$order->id}/transactions", ['simulate' => 'reject'])->assertStatus(402);
+        $this->postJson("/api/v1/orders/{$order->id}/transactions", [])->assertCreated();
+
+        $this->assertSame(Constant::ORDER_STATUS_CONFIRMED, $order->fresh()->status);
+        $this->assertSame(2, Transaction::where('order_id', $order->id)->count());
+    }
+
+    public function test_paid_order_rejects_second_charge(): void
+    {
+        $user = $this->customer();
+        $order = $this->pendingOrderFor($user);
+
+        $this->postJson("/api/v1/orders/{$order->id}/transactions", [])->assertCreated();
+        $response = $this->postJson("/api/v1/orders/{$order->id}/transactions", []);
+
+        $response->assertUnprocessable();
+        // Sin segundo cargo: sigue habiendo una sola transaccion approved.
+        $this->assertSame(
+            1,
+            Transaction::where('order_id', $order->id)
+                ->where('status', TransactionStatus::Approved->value)
+                ->count()
+        );
+    }
+
+    public function test_non_owner_cannot_pay_the_order(): void
+    {
+        $owner = User::factory()->create();
+        $order = $this->pendingOrderFor($owner);
+
+        // customer() autentica a OTRO usuario con el permiso correcto.
+        $this->customer();
+
+        $response = $this->postJson("/api/v1/orders/{$order->id}/transactions", []);
+
+        $response->assertForbidden();
+        $this->assertSame(0, Transaction::where('order_id', $order->id)->count());
+    }
+
+    public function test_nonexistent_order_returns_forbidden_without_leaking_existence(): void
+    {
+        $this->customer();
+
+        // 403 tanto para orden ajena como inexistente: no se filtra si el id existe.
+        $this->postJson('/api/v1/orders/999999/transactions', [])->assertForbidden();
+    }
+
+    public function test_user_without_pay_permission_gets_forbidden(): void
+    {
+        $user = User::factory()->create();
+        $user->assignRole('user'); // sin customer.orders.pay
+        Sanctum::actingAs($user);
+        $order = $this->pendingOrderFor($user);
+
+        $this->postJson("/api/v1/orders/{$order->id}/transactions", [])->assertForbidden();
+    }
+
+    public function test_transaction_response_does_not_expose_raw_gateway_payload(): void
+    {
+        $user = $this->customer();
+        $order = $this->pendingOrderFor($user);
+
+        $response = $this->postJson("/api/v1/orders/{$order->id}/transactions", []);
+
+        $response->assertCreated();
+        $this->assertArrayNotHasKey('payload', $response->json('data'));
+        // Pero el payload SI queda persistido para trazabilidad interna.
+        $this->assertNotEmpty(Transaction::where('order_id', $order->id)->first()->payload);
+    }
+
+    public function test_gateway_is_swappable_via_config_without_touching_domain(): void
+    {
+        // Gateway alterno inline: siempre rechaza con una firma reconocible.
+        $alternative = new class implements PaymentGatewayInterface
+        {
+            public function authorize(PaymentIntent $intent): PaymentResult
+            {
+                return new PaymentResult(
+                    status: TransactionStatus::Rejected,
+                    externalId: 'alt_gateway_ref',
+                    failureReason: 'Rejected by alternative gateway',
+                );
+            }
+
+            public function status(string $providerReference): PaymentResult
+            {
+                return new PaymentResult(status: TransactionStatus::Rejected, externalId: $providerReference);
+            }
+        };
+
+        // Swap por contenedor: mismo mecanismo que usaria una pasarela real
+        // registrada en config/payments.php. Ningun archivo de dominio cambia.
+        $this->app->singleton(PaymentGatewayInterface::class, fn () => $alternative);
+
+        $user = $this->customer();
+        $order = $this->pendingOrderFor($user);
+
+        $response = $this->postJson("/api/v1/orders/{$order->id}/transactions", []);
+
+        $response->assertStatus(402);
+        $response->assertJsonPath('data.external_id', 'alt_gateway_ref');
+        $this->assertSame(Constant::ORDER_STATUS_PENDING, $order->fresh()->status);
+    }
+}

--- a/app/backend/tests/Unit/Payments/FakePaymentGatewayTest.php
+++ b/app/backend/tests/Unit/Payments/FakePaymentGatewayTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Payments;
+
+use App\Enums\TransactionStatus;
+use App\Payments\Gateways\FakePaymentGateway;
+use App\Payments\PaymentIntent;
+use PHPUnit\Framework\TestCase;
+
+class FakePaymentGatewayTest extends TestCase
+{
+    private function intent(array $options = []): PaymentIntent
+    {
+        return new PaymentIntent(orderId: 1, amount: 100.0, currency: 'COP', options: $options);
+    }
+
+    public function test_approves_by_default(): void
+    {
+        $result = (new FakePaymentGateway)->authorize($this->intent());
+
+        $this->assertTrue($result->isApproved());
+        $this->assertSame(TransactionStatus::Approved, $result->status);
+        $this->assertStringStartsWith('fake_', $result->externalId);
+        $this->assertNull($result->failureReason);
+    }
+
+    public function test_rejects_deterministically_with_simulate_flag(): void
+    {
+        $result = (new FakePaymentGateway)->authorize(
+            $this->intent([FakePaymentGateway::SIMULATE_OPTION => FakePaymentGateway::SIMULATE_REJECT])
+        );
+
+        $this->assertFalse($result->isApproved());
+        $this->assertSame(TransactionStatus::Rejected, $result->status);
+        $this->assertNotNull($result->failureReason);
+    }
+
+    public function test_unknown_simulate_values_do_not_trigger_rejection(): void
+    {
+        $result = (new FakePaymentGateway)->authorize(
+            $this->intent([FakePaymentGateway::SIMULATE_OPTION => 'anything-else'])
+        );
+
+        $this->assertTrue($result->isApproved());
+    }
+}

--- a/app/frontend/src/app/app/(protected)/cart/page.tsx
+++ b/app/frontend/src/app/app/(protected)/cart/page.tsx
@@ -3,30 +3,42 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import { AlertCircle, ArrowLeft, CheckCircle2, CreditCard, Store } from "lucide-react";
+import { AlertCircle, ArrowLeft, CheckCircle2, CreditCard, FlaskConical, Store } from "lucide-react";
 import { ApiError } from "@/lib/api/client";
 import { getProductDetail } from "@/lib/api/app-catalog";
 import { createOrder, isInsufficientStockError } from "@/lib/api/app-orders";
+import { payOrder } from "@/lib/api/app-payments";
 import { mapProductDetailToView, type ProductDetailView } from "@/types/app-catalog.adapters";
 import type { AppOrder } from "@/types/app-orders";
+import type { AppTransaction } from "@/types/app-payments";
 
-const SAVED_PAYMENT_METHODS = [
+/**
+ * Selector de pago simulado (no hay pasarela real contratada aún).
+ * Opciones honestas: nada de tarjetas ficticias con apariencia real.
+ * "reject" expone el camino de rechazo determinista para QA.
+ * Cuando llegue la pasarela real, esto se reemplaza por los métodos
+ * reales del usuario (payment_methods) — ver SCRUM-352.
+ */
+const SIMULATED_PAYMENT_OPTIONS = [
   {
-    id: "card-default",
-    label: "Pago con tarjeta debito o credito",
-    detail: "**** 4532",
+    id: "approve",
+    label: "Pago simulado",
+    detail: "Aprobación inmediata (pasarela de prueba)",
     isDefault: true,
   },
   {
-    id: "cash",
-    label: "Efectivo",
-    detail: "Pago en tienda",
+    id: "reject",
+    label: "Pago simulado — rechazo",
+    detail: "Fuerza un rechazo para pruebas de QA",
     isDefault: false,
   },
 ] as const;
 
+type SimulatedOptionId = (typeof SIMULATED_PAYMENT_OPTIONS)[number]["id"];
+
 type LoadState = "loading" | "not-found" | "error" | "loaded";
 type OrderState = "idle" | "submitting" | "created" | "error";
+type PayState = "idle" | "paying" | "approved" | "rejected" | "error";
 
 function formatPrice(value: number): string {
   return `$${value.toLocaleString("es-CO")}`;
@@ -49,10 +61,13 @@ export default function AppCartPage() {
   const [loadState, setLoadState] = useState<LoadState>("loading");
   const [product, setProduct] = useState<ProductDetailView | null>(null);
   const [quantity, setQuantity] = useState(1);
-  const [selectedPaymentId, setSelectedPaymentId] = useState<string>(SAVED_PAYMENT_METHODS[0].id);
+  const [selectedPaymentId, setSelectedPaymentId] = useState<SimulatedOptionId>("approve");
   const [orderState, setOrderState] = useState<OrderState>("idle");
   const [orderError, setOrderError] = useState<string | null>(null);
   const [createdOrder, setCreatedOrder] = useState<AppOrder | null>(null);
+  const [payState, setPayState] = useState<PayState>("idle");
+  const [payError, setPayError] = useState<string | null>(null);
+  const [transaction, setTransaction] = useState<AppTransaction | null>(null);
 
   useEffect(() => {
     // Sin productId/branchId no hay nada que buscar; el render maneja esos
@@ -127,6 +142,34 @@ export default function AppCartPage() {
     }
   };
 
+  const handlePay = async () => {
+    if (!createdOrder) {
+      return;
+    }
+
+    setPayState("paying");
+    setPayError(null);
+
+    try {
+      const result = await payOrder(
+        createdOrder.id,
+        selectedPaymentId === "reject" ? { simulate: "reject" } : {}
+      );
+
+      if (result.approved) {
+        setTransaction(result.transaction);
+        setPayState("approved");
+      } else {
+        setTransaction(result.transaction);
+        setPayError(result.reason);
+        setPayState("rejected");
+      }
+    } catch (error) {
+      setPayError(error instanceof ApiError ? error.message : "No se pudo procesar el pago. Intenta de nuevo.");
+      setPayState("error");
+    }
+  };
+
   if (!productId) {
     return (
       <section className="flex min-h-[60vh] flex-col items-center justify-center gap-3 px-4 text-center">
@@ -171,6 +214,21 @@ export default function AppCartPage() {
     );
   }
 
+  if (loadState === "not-found") {
+    return (
+      <section className="flex min-h-[60vh] flex-col items-center justify-center gap-3 px-4 text-center">
+        <AlertCircle className="h-8 w-8 text-[var(--color-app-text-secondary-purple)]" />
+        <h1 className="text-lg text-[var(--color-app-text-dark)]">Producto no encontrado</h1>
+        <Link
+          href="/app/discover"
+          className="mt-2 inline-flex h-9 items-center rounded-xl border border-[var(--color-app-ui-divider)] px-3 text-xs text-[var(--color-app-text-primary-purple)] transition hover:bg-[var(--color-app-ui-background-soft)]"
+        >
+          Volver a Descubre
+        </Link>
+      </section>
+    );
+  }
+
   if (loadState === "loading" || !product) {
     return (
       <section className="flex min-h-[60vh] items-center justify-center px-4">
@@ -179,14 +237,66 @@ export default function AppCartPage() {
     );
   }
 
+  // ============================================
+  // Pantalla de éxito: pago aprobado
+  // ============================================
+  if (payState === "approved" && createdOrder && transaction) {
+    return (
+      <section className="flex min-h-[70vh] flex-col items-center justify-center gap-4 px-4 text-center">
+        <span className="flex h-16 w-16 items-center justify-center rounded-full bg-[var(--color-app-tomatillo-soft)]">
+          <CheckCircle2 className="h-9 w-9 text-[var(--color-app-status-success)]" aria-hidden="true" />
+        </span>
+
+        <div>
+          <h1 className="text-xl text-[var(--color-app-text-dark)]">¡Pago aprobado!</h1>
+          <p className="mt-1 text-sm text-[var(--color-app-text-secondary-purple)]">
+            Tu pedido quedó confirmado y el comercio lo empezará a preparar.
+          </p>
+        </div>
+
+        <div className="app-surface w-full max-w-sm p-4 text-left">
+          <h2 className="text-base text-[var(--color-app-text-dark)]">Resumen</h2>
+          <dl className="mt-3 space-y-2 text-sm">
+            <div className="flex items-center justify-between">
+              <dt className="text-[var(--color-app-text-secondary-purple)]">Pedido</dt>
+              <dd className="text-[var(--color-app-text-dark)]">#{createdOrder.id}</dd>
+            </div>
+            <div className="flex items-center justify-between">
+              <dt className="text-[var(--color-app-text-secondary-purple)]">Producto</dt>
+              <dd className="text-[var(--color-app-text-dark)]">{product.title}</dd>
+            </div>
+            <div className="flex items-center justify-between">
+              <dt className="text-[var(--color-app-text-secondary-purple)]">Total pagado</dt>
+              <dd className="text-[var(--color-app-text-dark)]">
+                {formatPrice(transaction.amount)} {transaction.currency}
+              </dd>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <dt className="text-[var(--color-app-text-secondary-purple)]">Referencia</dt>
+              <dd className="truncate text-xs text-[var(--color-app-text-secondary-purple)]">
+                {transaction.external_id ?? "—"}
+              </dd>
+            </div>
+          </dl>
+        </div>
+
+        <Link href="/app/discover" className="app-btn-primary w-full max-w-sm">
+          Volver a Descubre
+        </Link>
+      </section>
+    );
+  }
+
   const subtotal = product.price * quantity;
+  const orderCreated = orderState === "created" && createdOrder !== null;
+  const isBusy = orderState === "submitting" || payState === "paying";
 
   return (
     <section className="px-4 pb-6 pt-4">
       <header className="app-page-header">
         <div className="flex items-center gap-3">
           <Link
-            href={`/app/product/${product.id}`}
+            href={`/app/product/${product.id}?branchId=${branchId}`}
             className="app-btn-icon app-header-back-button"
             aria-label="Volver a producto"
           >
@@ -195,7 +305,9 @@ export default function AppCartPage() {
 
           <div>
             <h1 className="text-xl text-[var(--color-app-text-dark)]">Tu pedido</h1>
-            <p className="text-sm text-[var(--color-app-text-secondary-purple)]">Paso previo al pago</p>
+            <p className="text-sm text-[var(--color-app-text-secondary-purple)]">
+              {orderCreated ? "Confirma el pago para completar tu compra" : "Paso previo al pago"}
+            </p>
           </div>
         </div>
       </header>
@@ -212,7 +324,7 @@ export default function AppCartPage() {
               <button
                 type="button"
                 onClick={() => setQuantity((prev) => Math.max(1, prev - 1))}
-                disabled={orderState === "created"}
+                disabled={orderCreated || isBusy}
                 className="flex h-9 w-9 items-center justify-center rounded-xl border border-[var(--color-app-ui-divider)] text-[var(--color-app-text-primary-purple)] transition hover:bg-[var(--color-app-ui-background-soft)] disabled:cursor-not-allowed disabled:opacity-60"
                 aria-label="Disminuir cantidad"
               >
@@ -222,7 +334,7 @@ export default function AppCartPage() {
               <button
                 type="button"
                 onClick={() => setQuantity((prev) => Math.min(product.quantityAvailable, prev + 1))}
-                disabled={orderState === "created"}
+                disabled={orderCreated || isBusy}
                 className="flex h-9 w-9 items-center justify-center rounded-xl border border-[var(--color-app-ui-divider)] text-[var(--color-app-text-primary-purple)] transition hover:bg-[var(--color-app-ui-background-soft)] disabled:cursor-not-allowed disabled:opacity-60"
                 aria-label="Aumentar cantidad"
               >
@@ -244,15 +356,17 @@ export default function AppCartPage() {
           <h2 className="text-base text-[var(--color-app-text-dark)]">Metodo de pago</h2>
 
           <div className="mt-3 space-y-2">
-            {SAVED_PAYMENT_METHODS.map((method) => {
+            {SIMULATED_PAYMENT_OPTIONS.map((method) => {
               const checked = selectedPaymentId === method.id;
+              const Icon = method.id === "reject" ? FlaskConical : CreditCard;
 
               return (
                 <button
                   key={method.id}
                   type="button"
                   onClick={() => setSelectedPaymentId(method.id)}
-                  className={`w-full rounded-xl border p-3 text-left ${
+                  disabled={isBusy}
+                  className={`w-full rounded-xl border p-3 text-left disabled:cursor-not-allowed disabled:opacity-60 ${
                     checked
                       ? "border-[var(--color-app-text-primary-purple)] bg-[var(--color-app-tomatillo-soft)]"
                       : "border-[var(--color-app-ui-divider)]"
@@ -267,7 +381,7 @@ export default function AppCartPage() {
                       }`}
                       aria-hidden="true"
                     />
-                    <CreditCard className="h-4 w-4 text-[var(--color-app-text-primary-purple)]" />
+                    <Icon className="h-4 w-4 text-[var(--color-app-text-primary-purple)]" />
                     <div className="flex-1">
                       <p className="text-sm text-[var(--color-app-text-dark)]">{method.label}</p>
                       <p className="text-xs text-[var(--color-app-text-secondary-purple)]">{method.detail}</p>
@@ -294,27 +408,10 @@ export default function AppCartPage() {
           </div>
         </article>
 
-        {orderState === "created" && createdOrder ? (
-          <>
-            <div className="app-surface-outlined p-3 text-xs text-[var(--color-app-status-success)]">
-              <div className="flex items-start gap-2">
-                <CheckCircle2 className="mt-0.5 h-4 w-4" />
-                <p>
-                  Pedido #{createdOrder.id} creado, pendiente de pago. La confirmación y el procesamiento de pago se
-                  habilitarán cuando se defina la pasarela.
-                </p>
-              </div>
-            </div>
-
-            <button type="button" disabled className="app-btn-primary w-full gap-2">
-              <CheckCircle2 className="h-4 w-4" />
-              Confirmacion de pago no disponible aún
-            </button>
-          </>
-        ) : (
+        {!orderCreated ? (
           <>
             {orderState === "error" && orderError && (
-              <div className="app-surface-outlined p-3 text-xs text-red-600">
+              <div className="app-surface-outlined p-3 text-xs text-red-600" role="alert">
                 <div className="flex items-start gap-2">
                   <AlertCircle className="mt-0.5 h-4 w-4" />
                   <p>{orderError}</p>
@@ -330,6 +427,47 @@ export default function AppCartPage() {
             >
               <CheckCircle2 className="h-4 w-4" />
               {orderState === "submitting" ? "Creando pedido..." : "Confirmar pedido"}
+            </button>
+          </>
+        ) : (
+          <>
+            <div className="app-surface-outlined p-3 text-xs text-[var(--color-app-text-secondary-purple)]">
+              <div className="flex items-start gap-2">
+                <CheckCircle2 className="mt-0.5 h-4 w-4 text-[var(--color-app-status-success)]" />
+                <p>
+                  Pedido #{createdOrder.id} creado. Confirma el pago para que el comercio lo prepare.
+                </p>
+              </div>
+            </div>
+
+            {(payState === "rejected" || payState === "error") && payError && (
+              <div className="app-surface-outlined p-3 text-xs text-red-600" role="alert">
+                <div className="flex items-start gap-2">
+                  <AlertCircle className="mt-0.5 h-4 w-4" />
+                  <div>
+                    <p>{payError}</p>
+                    {payState === "rejected" && (
+                      <p className="mt-1 text-[var(--color-app-text-secondary-purple)]">
+                        Puedes intentarlo de nuevo con otro método de pago.
+                      </p>
+                    )}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            <button
+              type="button"
+              onClick={handlePay}
+              disabled={payState === "paying"}
+              className="app-btn-primary w-full gap-2 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <CreditCard className="h-4 w-4" />
+              {payState === "paying"
+                ? "Procesando pago..."
+                : payState === "rejected" || payState === "error"
+                  ? "Reintentar pago"
+                  : `Pagar ${formatPrice(createdOrder.total_price)}`}
             </button>
           </>
         )}

--- a/app/frontend/src/app/app/(protected)/cart/page.tsx
+++ b/app/frontend/src/app/app/(protected)/cart/page.tsx
@@ -1,10 +1,14 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import { AlertCircle, ArrowLeft, CheckCircle2, CreditCard, Store, Truck } from "lucide-react";
-import { getStoreById } from "@/lib/app/mock-catalog";
+import { AlertCircle, ArrowLeft, CheckCircle2, CreditCard, Store } from "lucide-react";
+import { ApiError } from "@/lib/api/client";
+import { getProductDetail } from "@/lib/api/app-catalog";
+import { createOrder, isInsufficientStockError } from "@/lib/api/app-orders";
+import { mapProductDetailToView, type ProductDetailView } from "@/types/app-catalog.adapters";
+import type { AppOrder } from "@/types/app-orders";
 
 const SAVED_PAYMENT_METHODS = [
   {
@@ -21,105 +25,168 @@ const SAVED_PAYMENT_METHODS = [
   },
 ] as const;
 
-type DeliveryOption = "pickup" | "delivery";
-
-type CartItemView = {
-  id: number;
-  name: string;
-  category: string;
-  price: number;
-  originalPrice: number;
-  available: number;
-  pickupTime: string;
-  deliveryTime: string;
-  deliveryCost: number;
-  source: "query" | "mock";
-};
+type LoadState = "loading" | "not-found" | "error" | "loaded";
+type OrderState = "idle" | "submitting" | "created" | "error";
 
 function formatPrice(value: number): string {
   return `$${value.toLocaleString("es-CO")}`;
 }
 
-function toNumber(value: string | null, fallback: number): number {
+function parsePositiveInt(value: string | null): number | null {
   if (!value) {
-    return fallback;
+    return null;
   }
 
-  const parsed = Number(value);
-  return Number.isFinite(parsed) ? parsed : fallback;
-}
-
-function toText(value: string | null, fallback: string): string {
-  if (!value) {
-    return fallback;
-  }
-
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
 }
 
 export default function AppCartPage() {
   const searchParams = useSearchParams();
-  const storeIdRaw = searchParams.get("storeId");
-  const parsedStoreId = storeIdRaw ? Number.parseInt(storeIdRaw, 10) : 1;
-  const safeStoreId = Number.isNaN(parsedStoreId) ? 1 : parsedStoreId;
-  const source = searchParams.get("source");
+  const productId = parsePositiveInt(searchParams.get("productId"));
+  const branchId = parsePositiveInt(searchParams.get("branchId"));
 
-  const fallbackStore = getStoreById(safeStoreId) ?? getStoreById(1);
-
-  const queryProduct: CartItemView | null = source === "product-detail"
-    ? {
-        id: toNumber(searchParams.get("productId"), safeStoreId),
-        name: toText(searchParams.get("name"), "Producto"),
-        category: toText(searchParams.get("category"), "Sin categoria"),
-        price: toNumber(searchParams.get("price"), 0),
-        originalPrice: toNumber(searchParams.get("originalPrice"), toNumber(searchParams.get("price"), 0)),
-        available: Math.max(1, toNumber(searchParams.get("available"), 1)),
-        pickupTime: toText(searchParams.get("pickupTime"), "Consultar con el comercio"),
-        deliveryTime: toText(searchParams.get("deliveryTime"), "Consultar disponibilidad"),
-        deliveryCost: toNumber(searchParams.get("deliveryCost"), 0),
-        source: "query",
-      }
-    : null;
-
-  const cartItem: CartItemView | null = queryProduct
-    ?? (fallbackStore
-      ? {
-          id: fallbackStore.id,
-          name: fallbackStore.name,
-          category: fallbackStore.category,
-          price: fallbackStore.price,
-          originalPrice: fallbackStore.originalPrice,
-          available: fallbackStore.available,
-          pickupTime: fallbackStore.pickupTime,
-          deliveryTime: fallbackStore.deliveryTime,
-          deliveryCost: fallbackStore.deliveryCost,
-          source: "mock",
-        }
-      : null);
-
-  const maxAvailable = cartItem?.available ?? 1;
-  const storePrice = cartItem?.price ?? 0;
-  const storeDeliveryCost = cartItem?.deliveryCost ?? 0;
-
+  const [loadState, setLoadState] = useState<LoadState>("loading");
+  const [product, setProduct] = useState<ProductDetailView | null>(null);
   const [quantity, setQuantity] = useState(1);
-  const [deliveryOption, setDeliveryOption] = useState<DeliveryOption>("pickup");
   const [selectedPaymentId, setSelectedPaymentId] = useState<string>(SAVED_PAYMENT_METHODS[0].id);
+  const [orderState, setOrderState] = useState<OrderState>("idle");
+  const [orderError, setOrderError] = useState<string | null>(null);
+  const [createdOrder, setCreatedOrder] = useState<AppOrder | null>(null);
 
-  const subtotal = storePrice * quantity;
-  const deliveryFee = deliveryOption === "delivery" ? storeDeliveryCost : 0;
-  const total = subtotal + deliveryFee;
+  useEffect(() => {
+    // Sin productId/branchId no hay nada que buscar; el render maneja esos
+    // casos directamente (son conocidos de forma sincrona desde la URL, no
+    // requieren estado ni fetch).
+    if (!productId || !branchId) {
+      return;
+    }
 
-  if (!cartItem) {
-    return null;
+    let cancelled = false;
+
+    async function loadProduct() {
+      setLoadState("loading");
+
+      try {
+        const response = await getProductDetail(productId!);
+
+        if (cancelled) {
+          return;
+        }
+
+        const view = mapProductDetailToView(response.data);
+        setProduct(view);
+        setQuantity((prev) => Math.min(Math.max(prev, 1), Math.max(view.quantityAvailable, 1)));
+        setLoadState("loaded");
+      } catch (error) {
+        if (cancelled) {
+          return;
+        }
+
+        if (error instanceof ApiError && error.status === 404) {
+          setLoadState("not-found");
+        } else {
+          setLoadState("error");
+        }
+      }
+    }
+
+    void loadProduct();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [productId, branchId]);
+
+  const handleConfirmOrder = async () => {
+    if (!product || !branchId) {
+      return;
+    }
+
+    setOrderState("submitting");
+    setOrderError(null);
+
+    try {
+      const response = await createOrder({
+        commerce_branch_id: branchId,
+        items: [{ product_id: product.id, quantity }],
+      });
+
+      setCreatedOrder(response.data);
+      setOrderState("created");
+    } catch (error) {
+      if (isInsufficientStockError(error)) {
+        setOrderError("No hay suficiente disponibilidad para la cantidad solicitada.");
+      } else if (error instanceof ApiError) {
+        setOrderError(error.message);
+      } else {
+        setOrderError("No se pudo crear el pedido. Intenta de nuevo.");
+      }
+
+      setOrderState("error");
+    }
+  };
+
+  if (!productId) {
+    return (
+      <section className="flex min-h-[60vh] flex-col items-center justify-center gap-3 px-4 text-center">
+        <AlertCircle className="h-8 w-8 text-[var(--color-app-text-secondary-purple)]" />
+        <h1 className="text-lg text-[var(--color-app-text-dark)]">Producto no encontrado</h1>
+        <Link
+          href="/app/discover"
+          className="mt-2 inline-flex h-9 items-center rounded-xl border border-[var(--color-app-ui-divider)] px-3 text-xs text-[var(--color-app-text-primary-purple)] transition hover:bg-[var(--color-app-ui-background-soft)]"
+        >
+          Volver a Descubre
+        </Link>
+      </section>
+    );
   }
+
+  if (!branchId) {
+    return (
+      <section className="flex min-h-[60vh] flex-col items-center justify-center gap-3 px-4 text-center">
+        <AlertCircle className="h-8 w-8 text-[var(--color-app-text-secondary-purple)]" />
+        <h1 className="text-lg text-[var(--color-app-text-dark)]">No pudimos determinar la sucursal</h1>
+        <p className="text-sm text-[var(--color-app-text-secondary-purple)]">
+          Vuelve a intentar desde Descubre para completar tu pedido.
+        </p>
+        <Link
+          href="/app/discover"
+          className="mt-2 inline-flex h-9 items-center rounded-xl border border-[var(--color-app-ui-divider)] px-3 text-xs text-[var(--color-app-text-primary-purple)] transition hover:bg-[var(--color-app-ui-background-soft)]"
+        >
+          Volver a Descubre
+        </Link>
+      </section>
+    );
+  }
+
+  if (loadState === "error") {
+    return (
+      <section className="flex min-h-[60vh] flex-col items-center justify-center gap-3 px-4 text-center">
+        <AlertCircle className="h-8 w-8 text-[var(--color-app-text-secondary-purple)]" />
+        <p className="text-sm text-[var(--color-app-text-secondary-purple)]">
+          No se pudo cargar tu pedido en este momento. Intenta de nuevo.
+        </p>
+      </section>
+    );
+  }
+
+  if (loadState === "loading" || !product) {
+    return (
+      <section className="flex min-h-[60vh] items-center justify-center px-4">
+        <p className="text-sm text-[var(--color-app-text-secondary-purple)]">Cargando tu pedido...</p>
+      </section>
+    );
+  }
+
+  const subtotal = product.price * quantity;
 
   return (
     <section className="px-4 pb-6 pt-4">
       <header className="app-page-header">
         <div className="flex items-center gap-3">
           <Link
-            href={`/app/product/${cartItem.id}`}
+            href={`/app/product/${product.id}`}
             className="app-btn-icon app-header-back-button"
             aria-label="Volver a producto"
           >
@@ -136,8 +203,8 @@ export default function AppCartPage() {
       <div className="mt-4 space-y-4">
         <article className="app-surface p-4">
           <h2 className="text-base text-[var(--color-app-text-dark)]">Resumen</h2>
-          <p className="mt-2 text-sm text-[var(--color-app-text-secondary-purple)]">{cartItem.name}</p>
-          <p className="text-sm text-[var(--color-app-text-secondary-purple)]">Bolsa sorpresa de {cartItem.category.toLowerCase()}</p>
+          <p className="mt-2 text-sm text-[var(--color-app-text-secondary-purple)]">{product.title}</p>
+          <p className="text-sm text-[var(--color-app-text-secondary-purple)]">{product.category}</p>
 
           <div className="mt-3 flex items-center justify-between">
             <span className="text-sm text-[var(--color-app-text-secondary-purple)]">Cantidad</span>
@@ -145,7 +212,8 @@ export default function AppCartPage() {
               <button
                 type="button"
                 onClick={() => setQuantity((prev) => Math.max(1, prev - 1))}
-                className="flex h-9 w-9 items-center justify-center rounded-xl border border-[var(--color-app-ui-divider)] text-[var(--color-app-text-primary-purple)] transition hover:bg-[var(--color-app-ui-background-soft)]"
+                disabled={orderState === "created"}
+                className="flex h-9 w-9 items-center justify-center rounded-xl border border-[var(--color-app-ui-divider)] text-[var(--color-app-text-primary-purple)] transition hover:bg-[var(--color-app-ui-background-soft)] disabled:cursor-not-allowed disabled:opacity-60"
                 aria-label="Disminuir cantidad"
               >
                 -
@@ -153,8 +221,9 @@ export default function AppCartPage() {
               <span className="min-w-6 text-center text-sm text-[var(--color-app-text-dark)]">{quantity}</span>
               <button
                 type="button"
-                onClick={() => setQuantity((prev) => Math.min(maxAvailable, prev + 1))}
-                className="flex h-9 w-9 items-center justify-center rounded-xl border border-[var(--color-app-ui-divider)] text-[var(--color-app-text-primary-purple)] transition hover:bg-[var(--color-app-ui-background-soft)]"
+                onClick={() => setQuantity((prev) => Math.min(product.quantityAvailable, prev + 1))}
+                disabled={orderState === "created"}
+                className="flex h-9 w-9 items-center justify-center rounded-xl border border-[var(--color-app-ui-divider)] text-[var(--color-app-text-primary-purple)] transition hover:bg-[var(--color-app-ui-background-soft)] disabled:cursor-not-allowed disabled:opacity-60"
                 aria-label="Aumentar cantidad"
               >
                 +
@@ -164,46 +233,10 @@ export default function AppCartPage() {
         </article>
 
         <article className="app-surface p-4">
-          <h2 className="text-base text-[var(--color-app-text-dark)]">Metodo de entrega</h2>
-
-          <div className="mt-3 space-y-2">
-            <button
-              type="button"
-              onClick={() => setDeliveryOption("pickup")}
-              className={`w-full rounded-xl border p-3 text-left ${
-                deliveryOption === "pickup"
-                  ? "border-[var(--color-app-text-primary-purple)] bg-[var(--color-app-tomatillo-soft)]"
-                  : "border-[var(--color-app-ui-divider)]"
-              }`}
-            >
-              <div className="flex items-start gap-2">
-                <Store className="mt-0.5 h-4 w-4 text-[var(--color-app-text-primary-purple)]" />
-                <div>
-                  <p className="text-sm text-[var(--color-app-text-dark)]">Recoger en tienda</p>
-                  <p className="text-xs text-[var(--color-app-text-secondary-purple)]">{cartItem.pickupTime}</p>
-                </div>
-              </div>
-            </button>
-
-            <button
-              type="button"
-              onClick={() => setDeliveryOption("delivery")}
-              className={`w-full rounded-xl border p-3 text-left ${
-                deliveryOption === "delivery"
-                  ? "border-[var(--color-app-text-primary-purple)] bg-[var(--color-app-tomatillo-soft)]"
-                  : "border-[var(--color-app-ui-divider)]"
-              }`}
-            >
-              <div className="flex items-start gap-2">
-                <Truck className="mt-0.5 h-4 w-4 text-[var(--color-app-text-primary-purple)]" />
-                <div>
-                  <p className="text-sm text-[var(--color-app-text-dark)]">Envio a domicilio</p>
-                  <p className="text-xs text-[var(--color-app-text-secondary-purple)]">
-                    {cartItem.deliveryTime} · {formatPrice(cartItem.deliveryCost)}
-                  </p>
-                </div>
-              </div>
-            </button>
+          <h2 className="text-base text-[var(--color-app-text-dark)]">Entrega</h2>
+          <div className="mt-3 flex items-start gap-2 rounded-xl border border-[var(--color-app-ui-divider)] p-3">
+            <Store className="mt-0.5 h-4 w-4 text-[var(--color-app-text-primary-purple)]" />
+            <p className="text-sm text-[var(--color-app-text-dark)]">Recoger en sucursal</p>
           </div>
         </article>
 
@@ -254,39 +287,52 @@ export default function AppCartPage() {
         <article className="app-surface p-4">
           <h2 className="text-base text-[var(--color-app-text-dark)]">Total</h2>
           <div className="mt-3 space-y-2 text-sm text-[var(--color-app-text-secondary-purple)]">
-            <div className="flex items-center justify-between">
-              <span>Subtotal</span>
-              <span>{formatPrice(subtotal)}</span>
-            </div>
-            <div className="flex items-center justify-between">
-              <span>Entrega</span>
-              <span>{deliveryFee === 0 ? "Gratis" : formatPrice(deliveryFee)}</span>
-            </div>
             <div className="flex items-center justify-between border-t border-[var(--color-app-ui-divider)] pt-2 text-base text-[var(--color-app-text-dark)]">
               <span>Total</span>
-              <span>{formatPrice(total)}</span>
+              <span>{formatPrice(subtotal)}</span>
             </div>
           </div>
         </article>
 
-        <div className="app-surface-outlined p-3 text-xs text-[var(--color-app-text-secondary-purple)]">
-          <div className="flex items-start gap-2">
-            <AlertCircle className="mt-0.5 h-4 w-4 text-[var(--color-app-text-primary-purple)]" />
-            <p>
-              Flujo disponible hasta seleccion del metodo de pago. La confirmacion y el procesamiento de pago se
-              habilitaran cuando se defina el proveedor.
-            </p>
-          </div>
-        </div>
+        {orderState === "created" && createdOrder ? (
+          <>
+            <div className="app-surface-outlined p-3 text-xs text-[var(--color-app-status-success)]">
+              <div className="flex items-start gap-2">
+                <CheckCircle2 className="mt-0.5 h-4 w-4" />
+                <p>
+                  Pedido #{createdOrder.id} creado, pendiente de pago. La confirmación y el procesamiento de pago se
+                  habilitarán cuando se defina la pasarela.
+                </p>
+              </div>
+            </div>
 
-        <button
-          type="button"
-          disabled
-          className="app-btn-primary w-full gap-2"
-        >
-          <CheckCircle2 className="h-4 w-4" />
-          Confirmacion de pago no disponible aún
-        </button>
+            <button type="button" disabled className="app-btn-primary w-full gap-2">
+              <CheckCircle2 className="h-4 w-4" />
+              Confirmacion de pago no disponible aún
+            </button>
+          </>
+        ) : (
+          <>
+            {orderState === "error" && orderError && (
+              <div className="app-surface-outlined p-3 text-xs text-red-600">
+                <div className="flex items-start gap-2">
+                  <AlertCircle className="mt-0.5 h-4 w-4" />
+                  <p>{orderError}</p>
+                </div>
+              </div>
+            )}
+
+            <button
+              type="button"
+              onClick={handleConfirmOrder}
+              disabled={orderState === "submitting"}
+              className="app-btn-primary w-full gap-2 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <CheckCircle2 className="h-4 w-4" />
+              {orderState === "submitting" ? "Creando pedido..." : "Confirmar pedido"}
+            </button>
+          </>
+        )}
       </div>
     </section>
   );

--- a/app/frontend/src/app/app/(protected)/discover/page.tsx
+++ b/app/frontend/src/app/app/(protected)/discover/page.tsx
@@ -127,8 +127,12 @@ export default function AppDiscoverPage() {
   };
 
   // El detalle de producto obtiene sus propios datos por id (GET /catalog/products/{id});
-  // ya no se transportan datos por query params.
-  const buildProductHref = (card: DiscoverNearbyCard): string => `/app/product/${card.productId}`;
+  // ya no se transportan datos de negocio por query params. branchId es la
+  // excepción: es solo un identificador (no datos duplicados) necesario para
+  // crear la orden en el carrito, ya que un producto puede vender en varias
+  // sucursales y el pedido requiere una específica.
+  const buildProductHref = (card: DiscoverNearbyCard): string =>
+    card.branchId ? `/app/product/${card.productId}?branchId=${card.branchId}` : `/app/product/${card.productId}`;
 
   const handleLoadMore = async () => {
     if (!location || state !== "ready" || isLoadingMore || !hasMorePages) {

--- a/app/frontend/src/app/app/(protected)/product/[storeId]/page.tsx
+++ b/app/frontend/src/app/app/(protected)/product/[storeId]/page.tsx
@@ -6,23 +6,25 @@ import { mapProductDetailToView, type ProductDetailView } from "@/types/app-cata
 
 type ProductDetailPageProps = {
   params: Promise<{ storeId: string }>;
+  searchParams: Promise<{ branchId?: string }>;
 };
 
 function formatPrice(value: number): string {
   return `$${value.toLocaleString("es-CO")}`;
 }
 
-function buildCartHref(product: ProductDetailView): string {
-  const params = new URLSearchParams({
-    source: "product-detail",
-    productId: String(product.id),
-    name: product.title,
-    category: product.category,
-    price: String(product.price),
-    originalPrice: String(product.originalPrice),
-    available: String(product.quantityAvailable),
-    description: product.description,
-  });
+/**
+ * Solo se pasa el id de producto y, si se conoce, el de sucursal — no datos
+ * de negocio duplicados. El carrito hace su propio fetch con getProductDetail.
+ * branchId es necesario porque un producto puede venderse en varias sucursales
+ * y la orden requiere una específica (StoreOrderRequest exige commerce_branch_id).
+ */
+function buildCartHref(productId: number, branchId: number | null): string {
+  const params = new URLSearchParams({ productId: String(productId) });
+
+  if (branchId) {
+    params.set("branchId", String(branchId));
+  }
 
   return `/app/cart?${params.toString()}`;
 }
@@ -56,9 +58,12 @@ function ErrorState() {
   );
 }
 
-export default async function ProductDetailPage({ params }: ProductDetailPageProps) {
+export default async function ProductDetailPage({ params, searchParams }: ProductDetailPageProps) {
   const { storeId } = await params;
+  const { branchId: branchIdRaw } = await searchParams;
   const productId = Number.parseInt(storeId, 10);
+  const parsedBranchId = branchIdRaw ? Number.parseInt(branchIdRaw, 10) : NaN;
+  const branchId = Number.isInteger(parsedBranchId) && parsedBranchId > 0 ? parsedBranchId : null;
 
   if (!Number.isInteger(productId) || productId <= 0) {
     return <NotFoundState />;
@@ -136,7 +141,7 @@ export default async function ProductDetailPage({ params }: ProductDetailPagePro
               <p className="text-2xl text-[var(--color-app-text-dark)]">{formatPrice(product.price)}</p>
             </div>
 
-            <Link href={buildCartHref(product)} className="app-btn-primary gap-2">
+            <Link href={buildCartHref(product.id, branchId)} className="app-btn-primary gap-2">
               <Plus className="h-4 w-4" />
               Agregar al carrito
             </Link>

--- a/app/frontend/src/lib/api/app-payments.ts
+++ b/app/frontend/src/lib/api/app-payments.ts
@@ -1,0 +1,59 @@
+import { ApiError, fetchWithErrorHandling } from "./client";
+import type { AppTransaction, PayOrderPayload, PayOrderResult } from "@/types/app-payments";
+
+interface TransactionEnvelope {
+  status: boolean;
+  message: string | null;
+  data: AppTransaction;
+}
+
+function extractTransactionFromErrorData(data: unknown): AppTransaction | null {
+  if (data && typeof data === "object" && "data" in data) {
+    const inner = (data as { data: unknown }).data;
+    if (inner && typeof inner === "object" && "status" in inner && "order_id" in inner) {
+      return inner as AppTransaction;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * POST /api/v1/orders/{id}/transactions
+ * Cobra la orden vía la pasarela activa del backend.
+ *
+ * El rechazo de la pasarela (HTTP 402) NO se propaga como excepción: es un
+ * resultado de negocio que la UI muestra (mensaje + reintento). Solo los
+ * errores reales (orden no pagable 422, sin permiso 403, red) lanzan ApiError.
+ *
+ * @throws {ApiError} para errores distintos al rechazo de la pasarela.
+ */
+export async function payOrder(orderId: number, payload: PayOrderPayload = {}): Promise<PayOrderResult> {
+  if (!Number.isInteger(orderId) || orderId <= 0) {
+    throw new ApiError("Id de orden inválido.", 422);
+  }
+
+  try {
+    const response = await fetchWithErrorHandling<TransactionEnvelope>(
+      `/api/v1/orders/${orderId}/transactions`,
+      {
+        method: "POST",
+        body: JSON.stringify(payload),
+      }
+    );
+
+    return { approved: true, transaction: response.data };
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 402) {
+      const transaction = extractTransactionFromErrorData(error.data);
+
+      return {
+        approved: false,
+        transaction,
+        reason: transaction?.failure_reason ?? "El pago no fue aprobado por la pasarela.",
+      };
+    }
+
+    throw error;
+  }
+}

--- a/app/frontend/src/types/app-payments.ts
+++ b/app/frontend/src/types/app-payments.ts
@@ -1,0 +1,39 @@
+/**
+ * Tipos del módulo app para el pago de órdenes.
+ * Alineados al contrato del backend: TransactionResource + POST /orders/{id}/transactions.
+ */
+
+export type TransactionStatus = "initiated" | "approved" | "rejected" | "failed";
+
+/** Transacción devuelta por el backend (TransactionResource). El payload crudo del gateway nunca viaja. */
+export interface AppTransaction {
+  id: number;
+  order_id: number;
+  payment_method_id: number | null;
+  provider: string;
+  external_id: string | null;
+  status: TransactionStatus;
+  amount: number;
+  currency: string;
+  failure_reason: string | null;
+  created_at?: string;
+}
+
+/**
+ * Cuerpo de POST /orders/{id}/transactions.
+ * `simulate: "reject"` solo lo respeta la pasarela fake (camino de prueba QA);
+ * una pasarela real lo ignora.
+ */
+export interface PayOrderPayload {
+  payment_method_id?: number;
+  simulate?: "reject";
+}
+
+/**
+ * Resultado tipado del pago. El backend responde 201 (aprobado) o 402
+ * (rechazado, con la transacción en el cuerpo); ambos son resultados de
+ * negocio válidos para la UI — no excepciones.
+ */
+export type PayOrderResult =
+  | { approved: true; transaction: AppTransaction }
+  | { approved: false; transaction: AppTransaction | null; reason: string };


### PR DESCRIPTION
## Resumen

Cierra el flujo de checkout de la app móvil: carrito conectado a datos reales, creación de orden real, y capa de pago backend con pasarela simulada plug-in habilitada en el frontend.

Continúa sobre PR #110 (ya mergeado — catálogo real de la app).

**Fase 2 — Carrito + orden real**
- Carrito recibe solo `productId`+`branchId` (ids sueltos, sin datos de negocio duplicados) y crea la orden real vía `POST /orders`
- Retirada la opción de envío a domicilio: el modelo real de `Order` no tiene ese concepto

**Fase 3 — Capa de pago backend (núcleo, SCRUM-291)**
- Primer contrato con inversión de dependencia del proyecto: `PaymentGatewayInterface` + `FakePaymentGateway` (aprueba por defecto, rechaza con flag `simulate=reject` para QA)
- Tablas `transactions`/`payment_methods` alineadas al ER; `PaymentService` desacoplado del estado de orden, con lock pesimista (sin doble cobro)
- Endpoint `POST /orders/{id}/transactions`, permiso nuevo `customer.orders.pay`
- Enchufar una pasarela real = una clase nueva + una variable de entorno — verificado con test de swap de gateway

**Fase 4 — Pago en el frontend (cierre)**
- Botón de pago habilitado sobre la orden creada; pantalla de éxito con resumen y referencia del gateway; rechazo con motivo y reintento
- Selector de pago simulado honesto (aprobar / rechazo de prueba) en vez de un mock de tarjeta ficticia — gestión real de métodos de pago diferida a SCRUM-352 (post-MVP, bloqueada por pasarela real contratada)

Resuelve: SCRUM-291

## Test plan
- [x] Backend: 408/408 tests (12 nuevos de pago), Pint limpio
- [x] Frontend: `tsc --noEmit` y `eslint` limpios en todo `src/`
- [x] E2E backend con token real: orden creada, pago rechazado (402) y aprobado (201), doble cobro bloqueado (422), no-dueño (403)
- [x] E2E navegador real: confirmado por el usuario — camino aprobado (pantalla de éxito) y camino rechazado (motivo + reintento)