### PR TITLE
feat(app): cerrar gaps de diseño del flujo de pedido (SCRUM-158/159)

### DIFF
--- a/app/frontend/src/app/app/(protected)/cart/page.tsx
+++ b/app/frontend/src/app/app/(protected)/cart/page.tsx
@@ -1,14 +1,16 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { AlertCircle, ArrowLeft, CheckCircle2, CreditCard, FlaskConical, Store } from "lucide-react";
 import { ApiError } from "@/lib/api/client";
-import { getProductDetail } from "@/lib/api/app-catalog";
+import { getBranchDetail, getProductDetail } from "@/lib/api/app-catalog";
 import { createOrder, isInsufficientStockError } from "@/lib/api/app-orders";
 import { payOrder } from "@/lib/api/app-payments";
-import { mapProductDetailToView, type ProductDetailView } from "@/types/app-catalog.adapters";
+import { getTodayPickupSchedule, mapProductDetailToView, type ProductDetailView } from "@/types/app-catalog.adapters";
+import type { BranchDetail } from "@/types/app-catalog";
 import type { AppOrder } from "@/types/app-orders";
 import type { AppTransaction } from "@/types/app-payments";
 
@@ -57,10 +59,14 @@ export default function AppCartPage() {
   const searchParams = useSearchParams();
   const productId = parsePositiveInt(searchParams.get("productId"));
   const branchId = parsePositiveInt(searchParams.get("branchId"));
+  // qty es un id suelto que viaja desde el detalle de producto (no dato de
+  // negocio duplicado): solo fija el valor inicial, sigue editable aquí.
+  const qtyParam = parsePositiveInt(searchParams.get("qty"));
 
   const [loadState, setLoadState] = useState<LoadState>("loading");
   const [product, setProduct] = useState<ProductDetailView | null>(null);
-  const [quantity, setQuantity] = useState(1);
+  const [branch, setBranch] = useState<BranchDetail | null>(null);
+  const [quantity, setQuantity] = useState(qtyParam ?? 1);
   const [selectedPaymentId, setSelectedPaymentId] = useState<SimulatedOptionId>("approve");
   const [orderState, setOrderState] = useState<OrderState>("idle");
   const [orderError, setOrderError] = useState<string | null>(null);
@@ -82,28 +88,32 @@ export default function AppCartPage() {
     async function loadProduct() {
       setLoadState("loading");
 
-      try {
-        const response = await getProductDetail(productId!);
+      // Producto y sucursal en paralelo: la sucursal es informativa (horario
+      // de recogida) y su fallo no debe bloquear el producto.
+      const [productResult, branchResult] = await Promise.allSettled([
+        getProductDetail(productId!),
+        getBranchDetail(branchId!),
+      ]);
 
-        if (cancelled) {
-          return;
-        }
+      if (cancelled) {
+        return;
+      }
 
-        const view = mapProductDetailToView(response.data);
-        setProduct(view);
-        setQuantity((prev) => Math.min(Math.max(prev, 1), Math.max(view.quantityAvailable, 1)));
-        setLoadState("loaded");
-      } catch (error) {
-        if (cancelled) {
-          return;
-        }
-
+      if (productResult.status === "rejected") {
+        const error = productResult.reason;
         if (error instanceof ApiError && error.status === 404) {
           setLoadState("not-found");
         } else {
           setLoadState("error");
         }
+        return;
       }
+
+      const view = mapProductDetailToView(productResult.value.data);
+      setProduct(view);
+      setQuantity((prev) => Math.min(Math.max(prev, 1), Math.max(view.quantityAvailable, 1)));
+      setBranch(branchResult.status === "fulfilled" ? branchResult.value.data : null);
+      setLoadState("loaded");
     }
 
     void loadProduct();
@@ -280,6 +290,17 @@ export default function AppCartPage() {
           </dl>
         </div>
 
+        {branch && (
+          <div className="w-full max-w-sm rounded-2xl bg-[var(--color-app-tomatillo-soft)] p-4">
+            <p className="text-center text-sm text-[var(--color-app-text-dark)]">
+              Recoge en: <span className="font-semibold">{branch.commerce_name ?? branch.name}</span>
+            </p>
+            <p className="mt-1 text-center text-sm text-[var(--color-app-text-primary-purple)]">
+              {getTodayPickupSchedule(branch.hours) ?? "Consultar horario con el comercio"}
+            </p>
+          </div>
+        )}
+
         <Link href="/app/discover" className="app-btn-primary w-full max-w-sm">
           Volver a Descubre
         </Link>
@@ -315,8 +336,17 @@ export default function AppCartPage() {
       <div className="mt-4 space-y-4">
         <article className="app-surface p-4">
           <h2 className="text-base text-[var(--color-app-text-dark)]">Resumen</h2>
-          <p className="mt-2 text-sm text-[var(--color-app-text-secondary-purple)]">{product.title}</p>
-          <p className="text-sm text-[var(--color-app-text-secondary-purple)]">{product.category}</p>
+          <div className="mt-2 flex gap-3">
+            <div className="relative h-16 w-16 flex-shrink-0 overflow-hidden rounded-xl bg-gradient-to-br from-[var(--color-app-tomatillo-soft)] to-[var(--color-app-ui-background-soft)]">
+              {product.photoUrl && (
+                <Image src={product.photoUrl} alt={product.title} fill unoptimized className="object-cover" />
+              )}
+            </div>
+            <div className="min-w-0">
+              <p className="truncate text-sm text-[var(--color-app-text-secondary-purple)]">{product.title}</p>
+              <p className="text-sm text-[var(--color-app-text-secondary-purple)]">{product.category}</p>
+            </div>
+          </div>
 
           <div className="mt-3 flex items-center justify-between">
             <span className="text-sm text-[var(--color-app-text-secondary-purple)]">Cantidad</span>
@@ -348,7 +378,14 @@ export default function AppCartPage() {
           <h2 className="text-base text-[var(--color-app-text-dark)]">Entrega</h2>
           <div className="mt-3 flex items-start gap-2 rounded-xl border border-[var(--color-app-ui-divider)] p-3">
             <Store className="mt-0.5 h-4 w-4 text-[var(--color-app-text-primary-purple)]" />
-            <p className="text-sm text-[var(--color-app-text-dark)]">Recoger en sucursal</p>
+            <div>
+              <p className="text-sm text-[var(--color-app-text-dark)]">
+                Recoger en {branch?.name ?? "sucursal"}
+              </p>
+              <p className="mt-1 text-xs text-[var(--color-app-text-secondary-purple)]">
+                {getTodayPickupSchedule(branch?.hours) ?? "Consultar horario con el comercio"}
+              </p>
+            </div>
           </div>
         </article>
 

--- a/app/frontend/src/app/app/(protected)/product/[storeId]/page.tsx
+++ b/app/frontend/src/app/app/(protected)/product/[storeId]/page.tsx
@@ -1,32 +1,56 @@
+import Image from "next/image";
 import Link from "next/link";
-import { AlertCircle, ArrowLeft, Plus } from "lucide-react";
+import { AlertCircle, ArrowLeft, Clock3, Info, MapPin, Store } from "lucide-react";
 import { ApiError } from "@/lib/api/client";
-import { getProductDetail } from "@/lib/api/app-catalog";
-import { mapProductDetailToView, type ProductDetailView } from "@/types/app-catalog.adapters";
+import { getBranchDetail, getProductDetail } from "@/lib/api/app-catalog";
+import { getTodayPickupSchedule, mapProductDetailToView } from "@/types/app-catalog.adapters";
+import type { BranchDetail } from "@/types/app-catalog";
+import { ProductPurchasePanel } from "@/components/app/product/product-purchase-panel";
 
 type ProductDetailPageProps = {
   params: Promise<{ storeId: string }>;
   searchParams: Promise<{ branchId?: string }>;
 };
 
+const URGENT_STOCK_THRESHOLD = 3;
+
 function formatPrice(value: number): string {
   return `$${value.toLocaleString("es-CO")}`;
 }
 
 /**
- * Solo se pasa el id de producto y, si se conoce, el de sucursal — no datos
- * de negocio duplicados. El carrito hace su propio fetch con getProductDetail.
- * branchId es necesario porque un producto puede venderse en varias sucursales
- * y la orden requiere una específica (StoreOrderRequest exige commerce_branch_id).
+ * Etiqueta de cierre de la oferta (CA-01 de SCRUM-158), calculada al momento
+ * del render del server component. Degradación honesta: sin expires_at no se
+ * muestra nada (no se fabrica un horario).
  */
-function buildCartHref(productId: number, branchId: number | null): string {
-  const params = new URLSearchParams({ productId: String(productId) });
-
-  if (branchId) {
-    params.set("branchId", String(branchId));
+function buildExpiryLabel(expiresAt: string | null): string | null {
+  if (!expiresAt) {
+    return null;
   }
 
-  return `/app/cart?${params.toString()}`;
+  const expiry = new Date(expiresAt);
+  if (Number.isNaN(expiry.getTime())) {
+    return null;
+  }
+
+  const remainingMs = expiry.getTime() - Date.now();
+  if (remainingMs <= 0) {
+    return "Oferta finalizada";
+  }
+
+  const totalMinutes = Math.floor(remainingMs / 60_000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours >= 48) {
+    return `Termina el ${expiry.toLocaleDateString("es-CO", { day: "numeric", month: "short" })}`;
+  }
+
+  if (hours >= 1) {
+    return `Termina en ${hours}h ${minutes}min`;
+  }
+
+  return `Termina en ${minutes}min`;
 }
 
 function NotFoundState() {
@@ -69,12 +93,16 @@ export default async function ProductDetailPage({ params, searchParams }: Produc
     return <NotFoundState />;
   }
 
-  let product: ProductDetailView;
+  // Producto y sucursal se piden en paralelo: la sucursal es informativa
+  // (sección de recogida) y su fallo no debe bloquear ni retrasar el
+  // producto, que es el dato principal de la página.
+  const [productResult, branchResult] = await Promise.allSettled([
+    getProductDetail(productId),
+    branchId ? getBranchDetail(branchId) : Promise.resolve(null),
+  ]);
 
-  try {
-    const response = await getProductDetail(productId);
-    product = mapProductDetailToView(response.data);
-  } catch (error) {
+  if (productResult.status === "rejected") {
+    const error = productResult.reason;
     if (error instanceof ApiError && error.status === 404) {
       return <NotFoundState />;
     }
@@ -82,14 +110,36 @@ export default async function ProductDetailPage({ params, searchParams }: Produc
     return <ErrorState />;
   }
 
+  const product = mapProductDetailToView(productResult.value.data);
+
+  // Degradación honesta: sin branchId, o si la sucursal falla/no existe, la
+  // sección de recogida simplemente se omite — nunca se fabrica un horario
+  // o dirección.
+  const branch: BranchDetail | null =
+    branchResult.status === "fulfilled" && branchResult.value ? branchResult.value.data : null;
+
   const discount =
     product.originalPrice > product.price
       ? Math.round(((product.originalPrice - product.price) / product.originalPrice) * 100)
       : 0;
+  const expiryLabel = buildExpiryLabel(product.expiresAt);
+  const isUrgentStock = product.quantityAvailable > 0 && product.quantityAvailable <= URGENT_STOCK_THRESHOLD;
+  const pickupSchedule = getTodayPickupSchedule(branch?.hours);
 
   return (
     <section className="pb-6">
-      <div className="relative h-56 bg-gradient-to-br from-[var(--color-app-tomatillo-soft)] via-white to-[var(--color-app-ui-background-soft)] px-4 pt-4">
+      <div className="relative h-56 overflow-hidden bg-gradient-to-br from-[var(--color-app-tomatillo-soft)] via-white to-[var(--color-app-ui-background-soft)] px-4 pt-4">
+        {product.photoUrl && (
+          <Image
+            src={product.photoUrl}
+            alt={product.title}
+            fill
+            unoptimized
+            className="object-cover"
+            priority
+          />
+        )}
+
         <Link
           href="/app/discover"
           className="app-btn-icon app-header-back-button bg-white/90 text-[var(--color-app-text-dark)] shadow-[var(--app-shadow-button)]"
@@ -104,8 +154,22 @@ export default async function ProductDetailPage({ params, searchParams }: Produc
           </div>
         )}
 
-        <div className="absolute bottom-4 left-4 rounded-full bg-white px-3 py-1 text-xs text-[var(--color-app-text-secondary-purple)]">
-          Quedan {product.quantityAvailable} disponibles
+        <div className="absolute bottom-4 left-4 flex flex-col items-start gap-2">
+          {expiryLabel && (
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-white px-3 py-1 text-xs text-[var(--color-app-text-dark)]">
+              <Clock3 className="h-3.5 w-3.5 text-[var(--color-app-tomatillo-medium)]" aria-hidden="true" />
+              {expiryLabel}
+            </span>
+          )}
+          <span
+            className={`rounded-full px-3 py-1 text-xs ${
+              isUrgentStock
+                ? "bg-red-600 text-white"
+                : "bg-white text-[var(--color-app-text-secondary-purple)]"
+            }`}
+          >
+            {isUrgentStock ? `Solo quedan ${product.quantityAvailable}` : `Quedan ${product.quantityAvailable} disponibles`}
+          </span>
         </div>
       </div>
 
@@ -134,19 +198,38 @@ export default async function ProductDetailPage({ params, searchParams }: Produc
           <p className="mt-2 text-sm text-[var(--color-app-text-secondary-purple)]">{product.description}</p>
         </div>
 
-        <div className="app-surface p-4">
-          <div className="flex items-center justify-between gap-3">
-            <div>
-              <p className="text-sm text-[var(--color-app-text-secondary-purple)]">Total estimado</p>
-              <p className="text-2xl text-[var(--color-app-text-dark)]">{formatPrice(product.price)}</p>
+        {branch && (
+          <div className="app-surface p-4">
+            <h2 className="text-base text-[var(--color-app-text-dark)]">Recoger en tienda</h2>
+            <div className="mt-3 flex items-start gap-3">
+              <Store className="mt-0.5 h-4 w-4 flex-shrink-0 text-[var(--color-app-text-primary-purple)]" />
+              <div className="text-sm text-[var(--color-app-text-secondary-purple)]">
+                <p className="text-[var(--color-app-text-dark)]">{branch.name}</p>
+                {branch.address && (
+                  <p className="mt-0.5 flex items-start gap-1">
+                    <MapPin className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />
+                    {branch.address}
+                  </p>
+                )}
+                <p className="mt-1">{pickupSchedule ?? "Consultar con el comercio"}</p>
+              </div>
             </div>
-
-            <Link href={buildCartHref(product.id, branchId)} className="app-btn-primary gap-2">
-              <Plus className="h-4 w-4" />
-              Agregar al carrito
-            </Link>
           </div>
+        )}
+
+        <div className="app-surface-outlined flex gap-3 p-4">
+          <Info className="mt-0.5 h-5 w-5 flex-shrink-0 text-[var(--color-app-text-primary-purple)]" aria-hidden="true" />
+          <p className="text-sm text-[var(--color-app-text-dark)]">
+            Esta es una bolsa sorpresa. El contenido puede variar según disponibilidad del comercio.
+          </p>
         </div>
+
+        <ProductPurchasePanel
+          productId={product.id}
+          branchId={branchId}
+          price={product.price}
+          maxQuantity={product.quantityAvailable}
+        />
       </div>
     </section>
   );

--- a/app/frontend/src/components/app/product/product-purchase-panel.tsx
+++ b/app/frontend/src/components/app/product/product-purchase-panel.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { Minus, Plus } from "lucide-react";
+
+interface ProductPurchasePanelProps {
+  productId: number;
+  branchId: number | null;
+  price: number;
+  maxQuantity: number;
+}
+
+function formatPrice(value: number): string {
+  return `$${value.toLocaleString("es-CO")}`;
+}
+
+/**
+ * qty viaja como id suelto (no dato de negocio duplicado) igual que
+ * productId/branchId: el carrito vuelve a pedir el producto por id y usa
+ * qty solo como valor inicial editable (ver Fase 2 SCRUM-291).
+ */
+function buildCartHref(productId: number, branchId: number | null, quantity: number): string {
+  const params = new URLSearchParams({ productId: String(productId), qty: String(quantity) });
+
+  if (branchId) {
+    params.set("branchId", String(branchId));
+  }
+
+  return `/app/cart?${params.toString()}`;
+}
+
+/**
+ * Selector de cantidad + total en vivo del detalle de producto (CA-02/CA-04
+ * de SCRUM-158). Extraído a client component porque la página de detalle es
+ * server component (fetch de datos); la interactividad vive aquí.
+ */
+export function ProductPurchasePanel({ productId, branchId, price, maxQuantity }: ProductPurchasePanelProps) {
+  const safeMax = Math.max(maxQuantity, 1);
+  const [quantity, setQuantity] = useState(1);
+  const total = price * quantity;
+
+  return (
+    <>
+      <div className="app-surface p-4">
+        <h2 className="text-base text-[var(--color-app-text-dark)]">Cantidad</h2>
+        <div className="mt-3 flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => setQuantity((prev) => Math.max(1, prev - 1))}
+            disabled={quantity <= 1}
+            className="flex h-10 w-10 items-center justify-center rounded-full border-2 border-[var(--color-app-text-primary-purple)] text-[var(--color-app-text-primary-purple)] transition hover:bg-[var(--color-app-ui-background-soft)] disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label="Disminuir cantidad"
+          >
+            <Minus className="h-4 w-4" />
+          </button>
+          <span className="w-8 text-center text-xl text-[var(--color-app-text-dark)]">{quantity}</span>
+          <button
+            type="button"
+            onClick={() => setQuantity((prev) => Math.min(safeMax, prev + 1))}
+            disabled={quantity >= safeMax}
+            className="flex h-10 w-10 items-center justify-center rounded-full bg-[var(--color-app-text-primary-purple)] text-white transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label="Aumentar cantidad"
+          >
+            <Plus className="h-4 w-4" />
+          </button>
+          <span className="ml-2 text-sm text-[var(--color-app-text-secondary-purple)]">
+            Máximo {safeMax} disponibles
+          </span>
+        </div>
+      </div>
+
+      <div className="app-surface p-4">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-sm text-[var(--color-app-text-secondary-purple)]">Total</p>
+            <p className="text-2xl text-[var(--color-app-text-dark)]">{formatPrice(total)}</p>
+          </div>
+
+          <Link href={buildCartHref(productId, branchId, quantity)} className="app-btn-primary gap-2">
+            Agregar al carrito
+          </Link>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/app/frontend/src/types/app-catalog.adapters.ts
+++ b/app/frontend/src/types/app-catalog.adapters.ts
@@ -1,4 +1,10 @@
-import type { BranchDetail, NearbyBranch, NearbyProduct, NearbyProductsResponse, ProductDetail } from "./app-catalog";
+import type {
+  BranchDetail,
+  NearbyBranchHour,
+  NearbyProduct,
+  NearbyProductsResponse,
+  ProductDetail,
+} from "./app-catalog";
 
 export interface DiscoverNearbyCard {
   productId: number;
@@ -16,17 +22,20 @@ export interface DiscoverNearbyCard {
 }
 
 /**
- * Resuelve el horario de recogida de HOY para la sucursal asignada al producto.
+ * Resuelve el horario de recogida de HOY a partir de los horarios de una
+ * sucursal (NearbyBranch.hours o BranchDetail.hours — mismo shape).
  * day_of_week: 0=Domingo, 6=Sábado (mismo criterio que Date.getDay()).
  * Sin dato real → null (la UI decide el estado neutro, nunca se fabrica un horario).
+ * Reutilizada en discover, detalle de producto, carrito y pantalla de éxito
+ * — una sola fuente para esta lógica.
  */
-function getTodayPickupSchedule(branch: NearbyBranch | null): string | null {
-  if (!branch?.hours || branch.hours.length === 0) {
+export function getTodayPickupSchedule(hours: NearbyBranchHour[] | undefined | null): string | null {
+  if (!hours || hours.length === 0) {
     return null;
   }
 
   const todayIndex = new Date().getDay();
-  const todayHours = branch.hours.find((hour) => hour.day_of_week === todayIndex);
+  const todayHours = hours.find((hour) => hour.day_of_week === todayIndex);
 
   if (!todayHours) {
     return null;
@@ -159,7 +168,7 @@ export function mapNearbyProductToDiscoverCard(product: NearbyProduct): Discover
     available: toNumber(product.quantity_available, 1),
     distanceKm,
     imageUrl: getProductImageUrl(product),
-    pickupSchedule: getTodayPickupSchedule(nearestBranch),
+    pickupSchedule: getTodayPickupSchedule(nearestBranch?.hours),
   };
 }
 
@@ -242,6 +251,8 @@ export interface ProductDetailView {
   originalPrice: number;
   quantityAvailable: number;
   photoUrl: string | null;
+  /** ISO 8601 o null. Cierre de la oferta (products.expires_at); la vista decide el formato. */
+  expiresAt: string | null;
 }
 
 /**
@@ -261,6 +272,7 @@ export function mapProductDetailToView(detail: ProductDetail): ProductDetailView
     originalPrice: toNumber(detail.original_price, price),
     quantityAvailable: toNumber(detail.quantity_available, 0),
     photoUrl: detail.photos?.[0]?.presigned_url ?? null,
+    expiresAt: detail.expires_at ?? null,
   };
 }
 

--- a/app/frontend/src/types/app-catalog.ts
+++ b/app/frontend/src/types/app-catalog.ts
@@ -98,7 +98,7 @@ export interface BranchDetail {
   phone?: string | null;
   email?: string | null;
   is_active?: boolean | null;
-  hours?: Array<{ day_of_week: string; open_time: string; close_time: string; note?: string | null }>;
+  hours?: NearbyBranchHour[];
   photos?: Array<{ id: number; presigned_url?: string | null; file_path?: string }>;
   created_at?: string;
   updated_at?: string;


### PR DESCRIPTION
## Resumen

Auditoría del flujo real de pedido (detalle → carrito → pago → éxito) contra el mockup de Figma (`design-reference-app`) y contra los criterios de aceptación de SCRUM-158. Continúa sobre PR #111 (ya mergeado).

- **Foto real del producto** en detalle y carrito (antes solo gradiente decorativo)
- **Cantidad + total en vivo movidos al detalle** (CA-02/CA-04 de SCRUM-158), extraído a `ProductPurchasePanel`; viaja como `qty` en la URL, el carrito la mantiene editable con clamp anti-manipulación
- **Datos de recogida** (sucursal, dirección, horario de hoy) en las 3 pantallas donde faltaban: detalle, carrito y pantalla de éxito
- **Badge de urgencia** "Solo quedan X" (stock ≤3) e **info box** de bolsa sorpresa en el detalle

Corrige de paso un bug de tipos (`BranchDetail.hours[].day_of_week` tipado `string` cuando el backend lo serializa como número).

**Diferido, no es un hueco de este cierre:** domicilio (SCRUM-329, sin iniciar) y métodos de pago del perfil (SCRUM-352, post-MVP).

Resuelve: SCRUM-159 (subtask frontend de SCRUM-158)

## Test plan
- [x] `tsc --noEmit` y `eslint` (global, todo `src/`) limpios
- [x] E2E con datos reales sembrados: foto (fallback), badge urgencia con stock=2, badge de cierre de oferta en ambos formatos (minutos/horas), sección de recogida con sucursal/dirección/horario reales, info box
- [x] Datos de prueba restaurados a estado neutro para QA (stock=5, oferta a 2 días)