### PR TITLE
fix(orders): bloquear stock de producto al confirmar pago

### DIFF
--- a/app/backend/app/Services/ProductService.php
+++ b/app/backend/app/Services/ProductService.php
@@ -341,20 +341,25 @@ class ProductService
     /**
      * Dismiss confirmed stock for an order, reducing the total and available quantity of each product in the order.
      * This method is called when an order is confirmed, ensuring that the stock levels are updated accordingly.
+     *
+     * Se bloquea cada producto con lockForUpdate dentro de una transacción propia:
+     * dos confirmaciones concurrentes sobre el mismo producto (dos órdenes distintas)
+     * deben serializarse aquí, o de lo contrario ambas leerían el mismo quantity_total
+     * antes de restar y se perdería una de las dos actualizaciones (sobreventa).
      */
     public function dismissProductConfirmedStock(Order $order): void
     {
         try {
-            foreach ($order->items as $item) {
-                $product = Product::find($item->product_id);
-                if ($product) {
-
-                    ($product->quantity_total - $item->quantity) < 0 ? $product->quantity_total = 0 : $product->quantity_total -= $item->quantity;
-                    $product->quantity_available = $product->quantity_total; // Asumiendo que quantity_available refleja el stock actual disponible
-                    $product->save();
+            DB::transaction(function () use ($order) {
+                foreach ($order->items as $item) {
+                    $product = Product::query()->lockForUpdate()->find($item->product_id);
+                    if ($product) {
+                        ($product->quantity_total - $item->quantity) < 0 ? $product->quantity_total = 0 : $product->quantity_total -= $item->quantity;
+                        $product->quantity_available = $product->quantity_total; // Asumiendo que quantity_available refleja el stock actual disponible
+                        $product->save();
+                    }
                 }
-            }
-
+            });
         } catch (Exception $e) {
             Log::error('Error dismissing confirmed stock for order ID: '.$order->id, ['error' => $e->getMessage()]);
             throw $e;

--- a/app/backend/tests/Feature/Api/V1/OrderTransactionFeatureTest.php
+++ b/app/backend/tests/Feature/Api/V1/OrderTransactionFeatureTest.php
@@ -179,6 +179,56 @@ class OrderTransactionFeatureTest extends TestCase
         $this->assertNotEmpty(Transaction::where('order_id', $order->id)->first()->payload);
     }
 
+    public function test_paying_two_orders_for_the_same_product_decrements_stock_correctly(): void
+    {
+        // Regresion de un bug de concurrencia real: dismissProductConfirmedStock
+        // leia y escribia Product sin lockForUpdate, asi que dos confirmaciones
+        // sobre el mismo producto podian pisarse el descuento (lost update).
+        // Sqlite :memory: (el motor de esta suite) no permite simular la
+        // condicion de carrera real entre conexiones concurrentes; esta prueba
+        // solo cubre que el delta se aplica correctamente orden a orden, no que
+        // el lock resuelva la carrera en si (eso depende del motor real en prod).
+        $user = $this->customer();
+        $branch = CommerceBranch::factory()->create();
+        $product = Product::factory()->create([
+            'commerce_id' => $branch->commerce_id,
+            'quantity_total' => 10,
+            'quantity_available' => 10,
+        ]);
+
+        $orderA = Order::factory()->create([
+            'user_id' => $user->id,
+            'commerce_branch_id' => $branch->id,
+            'total_price' => 6000,
+            'status' => Constant::ORDER_STATUS_PENDING,
+        ]);
+        OrderItem::factory()->create([
+            'order_id' => $orderA->id,
+            'product_id' => $product->id,
+            'quantity' => 2,
+            'unit_price' => 3000,
+        ]);
+
+        $orderB = Order::factory()->create([
+            'user_id' => $user->id,
+            'commerce_branch_id' => $branch->id,
+            'total_price' => 9000,
+            'status' => Constant::ORDER_STATUS_PENDING,
+        ]);
+        OrderItem::factory()->create([
+            'order_id' => $orderB->id,
+            'product_id' => $product->id,
+            'quantity' => 3,
+            'unit_price' => 3000,
+        ]);
+
+        $this->postJson("/api/v1/orders/{$orderA->id}/transactions", [])->assertCreated();
+        $this->postJson("/api/v1/orders/{$orderB->id}/transactions", [])->assertCreated();
+
+        $this->assertSame(5, $product->fresh()->quantity_total);
+        $this->assertSame(5, $product->fresh()->quantity_available);
+    }
+
     public function test_gateway_is_swappable_via_config_without_touching_domain(): void
     {
         // Gateway alterno inline: siempre rechaza con una firma reconocible.


### PR DESCRIPTION
dismissProductConfirmedStock leia y escribia Product sin lockForUpdate, mientras PaymentService::pay solo bloqueaba la fila de Order. Dos confirmaciones concurrentes sobre el mismo producto podian pisarse el descuento de stock (lost update / sobreventa).